### PR TITLE
Make FindCOVER.cmake search for the correct covise-exports.cmake file

### DIFF
--- a/cmake/FindCOVER.cmake
+++ b/cmake/FindCOVER.cmake
@@ -32,7 +32,7 @@ find_path(COVISE_EXPORTS_FILEPATH "cover-exports.cmake"
    DOC "COVER - CMake library exports"
 )
 if (COVISE_EXPORTS_FILEPATH)
-   set(COVISE_EXPORTS_IMPORT "${COVISE_EXPORTS_FILEPATH}/cover-exports.cmake")
+   set(COVISE_EXPORTS_IMPORT "${COVISE_EXPORTS_FILEPATH}/covise-exports.cmake")
    include(${COVISE_EXPORTS_IMPORT})
    set(COVISE_OPTIONS_IMPORT "${COVISE_EXPORTS_FILEPATH}/CoviseOptions.cmake")
    include(${COVISE_OPTIONS_IMPORT})


### PR DESCRIPTION
The file is named covise-exports.cmake, not cover-exports.cmake