### PR TITLE
Document VRML plugin's dependency upon Flex and Bison

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Optional dependencies
 - **LibVncServer**
 - **VTK**
   Version 6 is required.
+- **Flex** and **Bison**
+  Lexer/Parser generators, required to build VRML plugin.
 
 CMake will show lists of met and unmet optional and required dependencies.
 You should check those and install additional prerequisites as needed.


### PR DESCRIPTION
Build currently fails with an obscure linker error, if Flex is missing.