### PR TITLE
Fix compile error: format ‘%d’ expects argument of type ‘int’

### DIFF
--- a/src/OpenCOVER/plugins/hlrs/Sensor/Sensor.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Sensor/Sensor.cpp
@@ -272,7 +272,7 @@ void VrmlNodeSensor::render(Viewer *)
         osg::Matrix m = cover->getViewerMat();
         m = m * cover->getInvBaseMat();
         pos = m.getTrans();
-        fprintf(fp, "pos %f %f %f time %d values %d %d %d\n", pos[0], pos[1], pos[2], currentTime, rpiBPM, rpiSPO2, rpiGSR);
+        fprintf(fp, "pos %f %f %f time %zd values %d %d %d\n", pos[0], pos[1], pos[2], currentTime, rpiBPM, rpiSPO2, rpiGSR);
         fflush(fp);
         oldTime = currentTime;
     }


### PR DESCRIPTION
Sensor.cpp:275:123: error: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘time_t {aka long int}’