### PR TITLE
Video plugin libav compatibility

### DIFF
--- a/cmake/Using/UseFFMPEG.cmake
+++ b/cmake/Using/UseFFMPEG.cmake
@@ -5,6 +5,18 @@ MACRO(USE_FFMPEG)
     if (NOT FFMPEG_FOUND)
       return()
     else()
+      message(STATUS "Checking whether we are actually compiling against libav")
+      try_compile(LIBAV_FOUND
+        "${CMAKE_BINARY_DIR}/tmp"
+        SOURCES
+          "${COVISEDIR}/cmake/tests/libav.c"
+        CMAKE_FLAGS
+          "-DINCLUDE_DIRECTORIES=${FFMPEG_INCLUDE_DIRS}"
+      )
+      if (LIBAV_FOUND)
+        add_definitions(-DHAVE_LIBAV)
+        message(STATUS "  using libav, not all features will be supported")
+      endif()
       ADD_DEFINITIONS(-DHAVE_FFMPEG)
       INCLUDE_DIRECTORIES(${FFMPEG_INCLUDE_DIRS})
       SET(EXTRA_LIBS ${EXTRA_LIBS} ${FFMPEG_LIBRARIES})

--- a/cmake/tests/libav.c
+++ b/cmake/tests/libav.c
@@ -1,0 +1,7 @@
+#include <libavcodec/version.h>
+
+#if LIBAVCODEC_VERSION_MICRO >= 100
+# error
+#endif
+
+int main(int argc, char **argv) {}

--- a/src/OpenCOVER/plugins/gpl/Video/FFMPEGVideo.cpp
+++ b/src/OpenCOVER/plugins/gpl/Video/FFMPEGVideo.cpp
@@ -141,11 +141,13 @@ bool FFMPEGPlugin::add_video_stream(AVCodec *codec, int w, int h, int frame_rate
     codecCtx->bit_rate_tolerance = 4000 * 1000;
     codecCtx->rc_buffer_aggressivity = 1.0;
 
-#if LIBAVFORMAT_VERSION_MAJOR < 54
+#if !defined(HAVE_LIBAV)
+# if LIBAVFORMAT_VERSION_MAJOR < 54
     oc->mux_rate = 2352 * 75 * 8;
     oc->preload = (int)(100 * AV_TIME_BASE);
-#else
+# else
     oc->audio_preload = (int)(100 * AV_TIME_BASE);
+# endif
 #endif
 
     oc->max_delay = (int)(0.7 * AV_TIME_BASE);


### PR DESCRIPTION
Ubuntu 14.04 uses libav-9, which provides neither preload nor audio_preload in AVFormatContext

Detection logic copied from MPV.