### PR TITLE
PointRaytracer Plugin

### DIFF
--- a/src/OpenCOVER/plugins/ukoeln/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/ukoeln/CMakeLists.txt
@@ -1,2 +1,3 @@
 ADD_SUBDIRECTORY(Utouch3D)
 ADD_SUBDIRECTORY(TouchInteraction)
+ADD_SUBDIRECTORY(PointRayTracer)

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/CMakeLists.txt
@@ -1,0 +1,20 @@
+#set(VISIONARAY_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/../3rdparty/visionaray/include")
+#include_directories(${VISIONARAY_INCLUDE_DIR})
+
+USING(VISIONARAY)
+
+SET(HEADERS
+  PointRayTracerGlobals.h
+  PointRayTracerPlugin.h
+  PointRayTracerDrawable.h
+  PointReader.h
+)
+SET(SOURCES
+  PointRayTracerPlugin.cpp
+  PointRayTracerDrawable.cpp
+  PointReader.cpp  
+)
+
+cover_add_plugin(PointRayTracerPlugin ${HEADERS} ${SOURCES})
+SET_TARGET_PROPERTIES(PointRayTracerPlugin PROPERTIES OUTPUT_NAME PointRayTracer)
+

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/Makefile
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/Makefile
@@ -1,0 +1,1 @@
+include $(COVISEDIR)/src/Makefile.default

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerDrawable.cpp
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerDrawable.cpp
@@ -1,0 +1,202 @@
+#include <GL/glew.h>
+#include "PointRayTracerDrawable.h"
+#include <iostream>
+
+#include <cover/coVRConfig.h>
+#include <cover/coVRLighting.h>
+#include <cover/coVRPluginSupport.h>
+#include <cover/VRSceneGraph.h>
+#include <cover/VRViewer.h>
+
+#include <visionaray/get_color.h>
+
+using namespace visionaray;
+
+visionaray::mat4 osg_cast(osg::Matrixd const &m)
+{
+    float arr[16];
+    std::copy(m.ptr(), m.ptr() + 16, arr);
+    return visionaray::mat4(arr);
+}
+
+
+PointRayTracerDrawable::PointRayTracerDrawable()
+{
+    setSupportsDisplayList(false);
+}
+
+PointRayTracerDrawable::~PointRayTracerDrawable()
+{
+
+}
+
+viewing_params PointRayTracerDrawable::getViewingParams(const osg::RenderInfo& info) const
+{
+    //get stereo mode, default to right eye
+    osg::DisplaySettings::StereoMode stereoMode = osg::DisplaySettings::StereoMode::RIGHT_EYE;
+    if(auto state = info.getState()) {
+        if(auto ds = state->getDisplaySettings()) {
+            stereoMode = ds->getStereoMode();
+        }
+    }
+
+    //Left or Right Eye?
+    eye current_eye = Right; //default
+    if(opencover::coVRConfig::instance()->stereoState())
+    {
+        switch(stereoMode)
+        {
+            case osg::DisplaySettings::ANAGLYPHIC:
+            {
+                if(m_total_frame_num % 2 == 0){
+                    current_eye = Left;
+                }
+            }
+            break;
+
+            case osg::DisplaySettings::QUAD_BUFFER:
+            {
+                GLint db = 0;
+                glGetIntegerv(GL_DRAW_BUFFER, &db);
+                if(db != GL_BACK_RIGHT && db != GL_FRONT_RIGHT && db != GL_RIGHT){
+                    current_eye = Left;
+                }
+            }
+            break;
+
+            case osg::DisplaySettings::LEFT_EYE:
+            {
+                current_eye = Left;
+            }
+            break;
+
+            case osg::DisplaySettings::RIGHT_EYE:
+            {
+                current_eye = Right;
+            }
+            break;
+
+            default:
+                break;
+        }
+    }
+
+    // Matrices
+    auto t = opencover::cover->getXformMat();
+    auto s = opencover::cover->getObjectsScale()->getMatrix();
+    auto v = current_eye == Right
+                 ? opencover::coVRConfig::instance()->channels[0].rightView
+                 : opencover::coVRConfig::instance()->channels[0].leftView;
+    auto view = osg_cast(s * t * v);
+    auto proj = current_eye == Right
+                    ? osg_cast(opencover::coVRConfig::instance()->channels[0].rightProj)
+                    : osg_cast(opencover::coVRConfig::instance()->channels[0].leftProj);
+
+    // Viewport
+    auto osg_cam = opencover::coVRConfig::instance()->channels[0].camera;
+    auto osg_viewport = osg_cam->getViewport();
+    int w = osg_viewport->width();
+    int h = osg_viewport->height();
+
+    viewing_params retval;
+    retval.view_matrix = view;
+    retval.proj_matrix = proj;
+    retval.width = w;
+    retval.height = h;
+
+    return retval;
+}
+
+void PointRayTracerDrawable::expandBoundingSphere(osg::BoundingSphere &bs)
+{
+    aabb bounds(vec3(std::numeric_limits<float>::max()), -vec3(std::numeric_limits<float>::max()));
+    for (auto const &point : *m_points)
+    {
+        bounds = combine(bounds, point.center);
+    }
+
+    auto c = bounds.center();
+    osg::BoundingSphere::vec_type center(c.x, c.y, c.z);
+    osg::BoundingSphere::value_type radius = length(c - bounds.min);
+    bs.set(center, radius);
+}
+
+PointRayTracerDrawable::PointRayTracerDrawable(const PointRayTracerDrawable &rhs, const osg::CopyOp &op)
+{
+    setSupportsDisplayList(false);
+}
+
+PointRayTracerDrawable *PointRayTracerDrawable::cloneType() const
+{
+    return new PointRayTracerDrawable();
+}
+
+osg::Object* PointRayTracerDrawable::clone(const osg::CopyOp &op) const
+{
+    return new PointRayTracerDrawable(*this, op);
+}
+
+void PointRayTracerDrawable::drawImplementation(osg::RenderInfo &info) const
+{
+    //init glew on first draw call
+    if(!m_glewIsInitialized){
+        if(glewInit() == GLEW_OK) m_glewIsInitialized = true;
+    }
+    //quit if init glew did not work
+    if(!m_glewIsInitialized) return;
+
+    auto vparams = getViewingParams(info);
+    if(vparams.width != m_host_rt.width() || vparams.height != m_host_rt.height()){
+        m_host_rt.resize(vparams.width, vparams.height);
+    }
+
+    auto sparams = make_sched_params(
+        vparams.view_matrix,
+        vparams.proj_matrix,
+        m_host_rt);
+
+    // some setup
+    using R = host_ray_type;
+    using S = R::scalar_type;
+    using C = visionaray::vector<4, S>;
+
+    auto bgcolor = visionaray::vec3(0.2,0.2,0.2);
+
+    // kernel with ray tracing logic
+    auto kernel = [&](R ray) -> visionaray::result_record<S>
+    {
+        visionaray::result_record<S> result;
+        result.color = C(bgcolor, 1.0f);
+
+        auto hit_rec = visionaray::closest_hit(
+                ray,
+                m_host_bvh_refs->begin(),
+                m_host_bvh_refs->end()
+                );
+
+        result.hit = hit_rec.hit;
+        result.isect_pos = ray.ori + ray.dir * hit_rec.t;
+
+        auto color = get_color(m_colors->data(),hit_rec,host_bvh_type(),visionaray::colors_per_face_binding());
+
+        result.color = select(
+                hit_rec.hit,
+                C(color, S(1.0)),
+                result.color
+                );
+
+        return result;
+    };
+
+    // call scheduler for actual rendering
+    m_scheduler->frame(kernel, sparams);
+
+    //display result
+    sparams.rt.display_color_buffer();
+
+    //update member
+    m_total_frame_num++;
+}
+
+
+

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerDrawable.h
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerDrawable.h
@@ -1,0 +1,38 @@
+#ifndef POINT_RAY_TRACER_DRAWABLE_H
+#define POINT_RAY_TRACER_DRAWABLE_H
+
+#include <osg/Drawable>
+
+#include "PointRayTracerGlobals.h"
+
+class PointRayTracerDrawable : public osg::Drawable
+{
+public:
+    PointRayTracerDrawable();
+    ~PointRayTracerDrawable();
+
+    void expandBoundingSphere(osg::BoundingSphere &bs);
+
+    std::vector<bvh_ref>*                        m_host_bvh_refs;
+    visionaray::aligned_vector<sphere_type>*     m_points;
+    visionaray::aligned_vector<color_type, 32>*  m_colors;
+    visionaray::tiled_sched<host_ray_type>*      m_scheduler;
+
+private:
+
+    //osg::Drawable interface
+    PointRayTracerDrawable* cloneType() const;    
+    osg::Object* clone(const osg::CopyOp& op) const;
+    PointRayTracerDrawable(PointRayTracerDrawable const& rhs, osg::CopyOp const& op = osg::CopyOp::SHALLOW_COPY);
+    void drawImplementation(osg::RenderInfo& info) const;
+
+    viewing_params getViewingParams(const osg::RenderInfo &info) const;
+
+    mutable size_t                  m_total_frame_num = 0;
+    mutable host_render_target_type m_host_rt;
+    mutable bool                    m_glewIsInitialized = false;
+
+};
+
+
+#endif //POINT_RAY_TRACER_DRAWABLE_H

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerGlobals.h
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerGlobals.h
@@ -1,0 +1,40 @@
+#ifndef POINT_RAY_TRACER_GLOBALS_H
+#define POINT_RAY_TRACER_GLOBALS_H
+
+#define USEOLD 0
+
+#include <visionaray/array_ref.h>
+#include <visionaray/bvh.h>
+#include <visionaray/camera.h>
+#include <visionaray/scheduler.h>
+#include <visionaray/traverse.h>
+#include <visionaray/cpu_buffer_rt.h>
+
+//Visionaray helpers
+template <typename P>
+using array_ref_bvh = visionaray::index_bvh_t<visionaray::array_ref<P>, visionaray::aligned_vector<visionaray::bvh_node>, visionaray::aligned_vector<unsigned>>;
+using host_ray_type = visionaray::basic_ray<visionaray::simd::float4>;
+using sphere_type   = visionaray::basic_sphere<float>;
+using color_type    = visionaray::vector<3, visionaray::unorm<8>>;
+using host_bvh_type = array_ref_bvh<sphere_type>;
+using bvh_ref       = host_bvh_type::bvh_ref;
+using host_render_target_type = visionaray::cpu_buffer_rt<visionaray::PF_RGBA8, visionaray::PF_DEPTH24_STENCIL8>;
+
+enum eye
+{
+    Left,
+    Right
+};
+
+struct viewing_params {
+#if(USEOLD)
+    host_render_target_type host_rt;
+#endif
+    visionaray::mat4 view_matrix;
+    visionaray::mat4 proj_matrix;
+    int width;
+    int height;
+};
+
+
+#endif //POINT_RAY_TRACER_GLOBALS_H

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerPlugin.cpp
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerPlugin.cpp
@@ -1,0 +1,77 @@
+ 
+/* This file is part of COVISE.
+
+   You can use it under the terms of the GNU Lesser General Public License
+   version 2.1 or later, see lgpl-2.1.txt.
+
+ * License: LGPL 2+ */
+#include <GL/glew.h>
+#include <cover/coVRPluginSupport.h>
+#include <config/CoviseConfig.h>
+#include "PointRayTracerPlugin.h"
+
+using namespace osg;
+PointRayTracerPlugin *PointRayTracerPlugin::plugin = NULL;
+
+//-----------------------------------------------------------------------------
+
+PointRayTracerPlugin::PointRayTracerPlugin() : m_scheduler(15)
+{
+
+
+}
+
+bool PointRayTracerPlugin::init()
+{
+    if (cover->debugLevel(1)) fprintf(stderr, "\n    new PointRayTracerPlugin\n");
+
+    //read config
+    std::string filename = covise::coCoviseConfig::getEntry("COVER.Plugin.PointRayTracer.Filename");
+    if(filename.empty()) filename = "/data/KleinAltendorf/ausschnitte/test_UTM_klein.pts";
+
+    float pointSize = covise::coCoviseConfig::getFloat("COVER.Plugin.PointRayTracer.PointSize",0.01f);
+
+    //create reader and read data into arrays
+    m_reader = new PointReader();
+    if(!m_reader->readFile(filename, pointSize, m_points, m_colors, m_bbox, true)) return false;
+
+    //build bvh
+    m_host_bvh = visionaray::build<host_bvh_type>(m_points.data(), m_points.size());
+    m_host_bvh_refs.push_back(m_host_bvh.ref());
+
+    //init drawable and set pointers to data
+    m_drawable = new PointRayTracerDrawable;
+    m_drawable->m_host_bvh_refs = &m_host_bvh_refs;
+    m_drawable->m_points = &m_points;
+    m_drawable->m_colors = &m_colors;
+    m_drawable->m_scheduler = &m_scheduler;
+
+    //init geode and add it to the scenegraph
+    m_geode = new osg::Geode;
+    m_geode->setName("PointRayTracer");
+    m_geode->addDrawable(m_drawable);
+    opencover::cover->getScene()->addChild(m_geode);
+
+    return true;
+}
+
+PointRayTracerPlugin::~PointRayTracerPlugin()
+{
+    if (cover->debugLevel(1))
+        fprintf(stderr, "\n    delete PointRayTracerPlugin\n");
+
+    delete m_reader;
+
+}
+
+void PointRayTracerPlugin::preFrame()
+{
+//    if (cover->debugLevel(1)) fprintf(stderr, "\n    preFrame PointRayTracerPlugin\n");
+}
+
+void PointRayTracerPlugin::expandBoundingSphere(osg::BoundingSphere &bs)
+{
+    m_drawable->expandBoundingSphere(bs);
+}
+
+COVERPLUGIN(PointRayTracerPlugin)

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerPlugin.h
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointRayTracerPlugin.h
@@ -1,0 +1,52 @@
+/* This file is part of COVISE.
+
+   You can use it under the terms of the GNU Lesser General Public License
+   version 2.1 or later, see lgpl-2.1.txt.
+
+ * License: LGPL 2+ */
+
+#ifndef POINT_RAY_TRACER_PLUGIN_H
+#define POINT_RAY_TRACER_PLUGIN_H
+
+#include "PointRayTracerGlobals.h"
+#include "PointReader.h"
+#include "PointRayTracerDrawable.h"
+
+#include <cover/coVRPlugin.h>
+
+using namespace opencover;
+
+
+
+class PointRayTracerPlugin : public coVRPlugin
+{
+
+public:
+    static PointRayTracerPlugin *plugin;
+
+    PointRayTracerPlugin();
+    virtual ~PointRayTracerPlugin();
+    bool init();
+    void preFrame();
+    void expandBoundingSphere(osg::BoundingSphere &bs);
+
+private:
+
+    PointReader* m_reader;
+
+    osg::ref_ptr<osg::Geode> m_geode;
+    osg::ref_ptr<PointRayTracerDrawable> m_drawable;
+
+    visionaray::aligned_vector<sphere_type>                                             m_points;
+    visionaray::aligned_vector<color_type, 32>                                          m_colors;
+    visionaray::aabb                                                                    m_bbox;
+    visionaray::tiled_sched<host_ray_type>                                              m_scheduler;
+
+    host_bvh_type                                   m_host_bvh;
+    std::vector<host_bvh_type>                      m_host_bvh_vector;
+    std::vector<bvh_ref>                            m_host_bvh_refs;
+
+};
+
+
+#endif //POINT_RAY_TRACER_PLUGIN_H

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointReader.cpp
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointReader.cpp
@@ -1,0 +1,172 @@
+#include "PointReader.h"
+#include <stdio.h>
+#include <iostream>
+#include <fstream>
+
+using namespace visionaray;
+
+PointReader::PointReader(){
+
+}
+
+std::vector<std::string> splitString(const std::string& s, char separator){
+    std::vector<std::string> retVal;
+    std::string::size_type prev_pos = 0, pos = 0;
+
+    while((pos = s.find(separator, pos)) != std::string::npos){
+        std::string substring(s.substr(prev_pos, pos - prev_pos));
+        if(substring != "") retVal.push_back(substring);
+        prev_pos = ++pos;
+    }
+
+    std::string substring(s.substr(prev_pos, pos - prev_pos));
+    if(substring != "") retVal.push_back(substring);
+
+    return retVal;
+}
+
+void addPoint(aligned_vector<sphere_type>& points,
+              aligned_vector<vector<3, unorm<8>>, 32>& colors,
+              std::vector<std::string>& tokens,
+              aabb& bbox,
+              int count,
+              bool cutUTMdata){
+
+    if(tokens.size() != 7){
+        std::cout << "PointReader::addPoint ERROR: size of stringlist != 7" << std::endl;
+        return;
+    }
+
+    if(cutUTMdata){
+        tokens[0] = tokens[0].substr(4,std::string::npos);
+        tokens[1] = tokens[1].substr(4,std::string::npos);
+    }
+
+    float x = std::stof(tokens[0]);
+    float y = std::stof(tokens[1]);
+    float z = std::stof(tokens[2]);
+
+    int r = std::stoi(tokens[4]);
+    int g = std::stoi(tokens[5]);
+    int b = std::stoi(tokens[6]);
+
+//        for(int i = 0; i < tokens.size(); i++){
+//            std::cout << "token " << i << " : " << tokens[i] << "  ";
+//        }
+//        std::cout << std::endl;
+//        std::cout << "x: " << x << "  y: " << y << "  z: " << z << "    r: " << r << "  g: " << g << "  b: " << b << std::endl << std::endl;
+
+    sphere_type sp;
+    sp.radius = 0.01f;
+    sp.center = vec3(x,y,z);
+    sp.prim_id = count;
+    sp.geom_id = 0;
+    points.push_back(sp);
+    colors.emplace_back((float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f);
+
+
+    if(x < bbox.min.x) bbox.min.x = x; else if(x > bbox.max.x) bbox.max.x = x;
+    if(y < bbox.min.y) bbox.min.y = y; else if(y > bbox.max.y) bbox.max.y = y;
+    if(z < bbox.min.z) bbox.min.z = z; else if(z > bbox.max.z) bbox.max.z = z;
+}
+
+
+bool PointReader::readFile(std::string filename, float pointSize,
+                           aligned_vector<sphere_type> &points,
+                           aligned_vector<vector<3, unorm<8>>, 32>& colors,
+                           aabb &bbox,
+                           bool cutUTMdata){
+
+    //open the file
+    FILE * f = fopen(filename.c_str(),"r");
+    if(f == NULL){
+        std::cerr << "PointReader::readFile() Could not open file: " << filename.c_str() << std::endl;
+        return false;
+    }
+
+    //data storage for ascii lines
+    char line[200];
+
+    //read the first line. Sometimes it contains the total number of points in the file
+    if(!fgets(line,200,f)) {
+        std::cout << "Could not read first line from file " << filename.c_str() << std::endl;
+        return false;
+    }
+
+    int numPoints = 0;
+    int count = 0;
+    std::vector<std::string> tokens = splitString(line, ' ');
+
+    if(tokens.size() != 7){
+        numPoints = std::stoi(tokens[0]);
+        if(numPoints != 0) std::cout << "PointReader::readFile() reading " << numPoints << "points" << std::endl;
+    } else {
+        addPoint(points,colors,tokens,bbox,count,cutUTMdata);
+        count++;
+    }
+
+    while(fgets(line,200,f)){
+
+        tokens = splitString(line,' ');
+        if(tokens.size() != 7) {
+            std::cout << "PointReader::readFile() ERROR: number of tokens not 7 in line " << count << " of file " << filename.c_str() << std::endl;
+            break;
+        }
+
+        addPoint(points,colors,tokens,bbox,count,cutUTMdata);
+        count++;
+
+        if(count % 100000 == 0) std::cout << "PointReader::readFile() reading line " << count << std::endl;
+    }
+
+
+    /*
+    //filename = "/data/KleinAltendorf/ausschnitte/test_UTM_KLA2506_2015.pts";
+    std::ifstream stream;
+    stream.open(filename.c_str());
+
+    if(!stream.is_open())
+    {
+        std::cerr << "PointReader::readFile() Could not open file: " << filename.c_str() << std::endl;
+        return false;
+    }
+    std::cout << "PointReader::readFile() reading file: " << filename.c_str() << std::endl;
+
+    std::string line;
+
+    int numPoints = 0;
+    std::getline(stream, line);
+    std::sscanf(line.c_str(),"%d",&numPoints);
+    std::cout << "PointReader::readFile() reading " << numPoints << "points" << std::endl;
+
+    int i = 0;
+    while(std::getline(stream, line)){
+
+        float x,y,z;
+        int r,g,b;
+        int ignore;
+        std::sscanf(line.c_str(),"%20f %20f %20f %i %i %i %i", &x, &y, &z, &ignore, &r, &g, &b);
+
+        sphere_type sp;
+        sp.radius = 0.01f;
+        sp.center = vec3(x,y,z);
+        sp.prim_id = i;
+        //sp.geom_id = current_geom;
+        points.push_back(sp);
+        colors.emplace_back((float)r / 255.0f, (float)g / 255.0f, (float)b / 255.0f);
+
+
+        if(x < bbox.min.x) bbox.min.x = x; else if(x > bbox.max.x) bbox.max.x = x;
+        if(y < bbox.min.y) bbox.min.y = y; else if(y > bbox.max.y) bbox.max.y = y;
+        if(z < bbox.min.z) bbox.min.z = z; else if(z > bbox.max.z) bbox.max.z = z;
+        i++;
+
+        if(i > 20) break;
+    }
+
+    stream.close();
+    std::cout << "done reading" << std::endl;
+    */
+
+    return true;
+}

--- a/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointReader.h
+++ b/src/OpenCOVER/plugins/ukoeln/PointRayTracer/PointReader.h
@@ -1,0 +1,32 @@
+#ifndef PRT_POINT_READER_H
+#define PRT_POINT_READER_H
+
+#include <visionaray/bvh.h>
+#include <visionaray/math/math.h>
+#include <visionaray/aligned_vector.h>
+
+using sphere_type   = visionaray::basic_sphere<float>;
+
+class PointReader {
+public:
+    PointReader();
+
+    bool readFile(std::string filename,
+                  float pointSize,
+                  visionaray::aligned_vector<sphere_type>& points,
+                  visionaray::aligned_vector<visionaray::vector<3, visionaray::unorm<8>>, 32>& colors,
+                  visionaray::aabb& bbox,
+                  bool cutUTMdata = false);
+
+private:
+
+    /*
+    char* m_filename;
+
+    visionaray::aligned_vector<sphere_type>                     m_points;
+    visionaray::aligned_vector<visionaray::vector<3, visionaray::unorm<8>>, 32>         m_colors;
+    */
+};
+
+
+#endif // PRT_POINT_READER_H


### PR DESCRIPTION
New plugin which uses visionaray from covise to raytrace pointclouds. Currently rather slow because cpu-raytracing is used. future commits will
- use gpu (cuda)
- change the way the filename is read (currently via config)
- read and write binary bvh-files (currently only ascii-pts files)
- allow for timesteps/multiple bvhs