### PR TITLE
redefined macro warning

### DIFF
--- a/src/OpenCOVER/plugins/gpl/StereoVideoPlayer/FFMPEGVideoPlayer.h
+++ b/src/OpenCOVER/plugins/gpl/StereoVideoPlayer/FFMPEGVideoPlayer.h
@@ -48,7 +48,7 @@ extern "C" {
 #endif
 };
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 24, 102)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 34, 1)
 typedef PixelFormat AVPixelFormat;
 
 #define AV_PIX_FMT_RGB24 PIX_FMT_RGB24

--- a/src/OpenCOVER/plugins/gpl/Video/FFMPEGVideo.h
+++ b/src/OpenCOVER/plugins/gpl/Video/FFMPEGVideo.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #include <xercesc/dom/DOM.hpp>
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 24, 102)
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(56, 34, 1)
 typedef PixelFormat AVPixelFormat;
 
 #ifndef AV_PIX_FMT_RGB32

--- a/src/module/hlrs/ReadGeoDict/CMakeLists.txt
+++ b/src/module/hlrs/ReadGeoDict/CMakeLists.txt
@@ -19,4 +19,8 @@ SET(EXTRASOURCES
 ADD_COVISE_MODULE(IO ReadGeoDict ${EXTRASOURCES} )
 TARGET_LINK_LIBRARIES(ReadGeoDict  coReader coApi coAppl coCore coUtil)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    ADD_COVISE_COMPILE_FLAGS(ReadGeoDict "-Wno-error=unused-result")
+endif()
+
 COVISE_INSTALL_TARGET(ReadGeoDict)


### PR DESCRIPTION
changed avcodec version to the one that actually introduced definitions