### PR TITLE
compile fix. Compile OpenCOVER.cpp without MPI

### DIFF
--- a/src/OpenCOVER/cover/OpenCOVER.cpp
+++ b/src/OpenCOVER/cover/OpenCOVER.cpp
@@ -374,7 +374,9 @@ bool OpenCOVER::init()
 
     if (m_forceMpi)
     {
+#ifdef HAS_MPI
         new coVRMSController(&m_comm);
+#endif
     }
     else
     {


### PR DESCRIPTION
The variable m_comm is not defined if HAS_MPI is undefined.