### PR TITLE
Show only the menu if configured to do so

### DIFF
--- a/src/3rdparty/CMakeLists.txt
+++ b/src/3rdparty/CMakeLists.txt
@@ -44,6 +44,7 @@ if (COVISE_USE_VISIONARAY)
    set(VISIONARAY_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/visionaray/include")
 
    if(MSVC)
+      set_target_properties(visionaray PROPERTIES OUTPUT_NAME "libvisionaray")
       set(VISIONARAY_LIBRARY "${COVISEDIR}/${ARCHSUFFIX}/lib/libvisionaray${CMAKE_STATIC_LIBRARY_SUFFIX}")
       set(VISIONARAY_LIBRARY_RELEASE "${COVISEDIR}/${ARCHSUFFIX}/lib/libvisionaray${CMAKE_STATIC_LIBRARY_SUFFIX}")
    else()

--- a/src/OpenCOVER/cover/VRSceneGraph.cpp
+++ b/src/OpenCOVER/cover/VRSceneGraph.cpp
@@ -112,8 +112,8 @@ VRSceneGraph::VRSceneGraph()
     , m_handLocked(false)
     , m_wireframe(Disabled)
     , m_textured(true)
-    , m_showMenu(true)
-    , m_showObjects(true)
+    , m_allowMenuOnly(false)
+    , m_menuState(ObjectsAndMenu)
     , m_pointerType(0)
     , m_worldTransformer(false)
     , m_worldTransformerEnabled(true)
@@ -239,6 +239,8 @@ int VRSceneGraph::readConfigFile()
     frameAngle = coCoviseConfig::getFloat("COVER.FrameAngle", 0.9);
 
     wiiPos = coCoviseConfig::getFloat("COVER.WiiPointerPos", -250.0);
+
+    m_allowMenuOnly = coCoviseConfig::isOn("COVER.AllowMenuOnlyState", false);
 
     return 0;
 }
@@ -642,9 +644,7 @@ bool VRSceneGraph::keyEvent(int type, int keySym, int mod)
 void
 VRSceneGraph::setObjects(bool state)
 {
-    m_showObjects = state;
-
-    if (m_showObjects)
+    if (state)
     {
         if (m_objectsTransform->getNumParents() == 1)
         {
@@ -664,9 +664,7 @@ VRSceneGraph::setObjects(bool state)
 void
 VRSceneGraph::setMenu(bool state)
 {
-    m_showMenu = state;
-
-    if (m_showMenu)
+    if (state)
     {
         if (m_menuGroupNode->getNumParents() == 0)
         {
@@ -776,9 +774,34 @@ void VRSceneGraph::applyMenuModeToMenus()
 void
 VRSceneGraph::toggleMenu()
 {
-    m_showMenu = !m_showMenu;
 
-    setMenu(m_showMenu);
+    if(m_menuState == ObjectsAndMenu)
+    {
+        m_menuState = ObjectsOnly;
+        setMenu(false);
+        setObjects(true);
+    }
+    else if(m_menuState == ObjectsOnly)
+    {
+        if(m_allowMenuOnly)
+        {
+            m_menuState = MenuOnly;
+            setMenu(true);
+            setObjects(false);
+        }
+        else
+        {
+            m_menuState = ObjectsAndMenu;
+            setMenu(true);
+            setObjects(true);
+        }
+    }
+    else if (m_menuState == MenuOnly)
+    {
+        m_menuState = ObjectsAndMenu;
+        setMenu(true);
+        setObjects(true);
+    }
 }
 
 void VRSceneGraph::setScaleFactor(float s, bool sync)

--- a/src/OpenCOVER/cover/VRSceneGraph.h
+++ b/src/OpenCOVER/cover/VRSceneGraph.h
@@ -60,6 +60,13 @@ public:
         HiddenLineBlack,
         HiddenLineWhite
     };
+
+    enum MenuVisibilityState {
+        ObjectsAndMenu,
+        ObjectsOnly,
+        MenuOnly
+    };
+
     VRSceneGraph();
     virtual ~VRSceneGraph();
     static VRSceneGraph *instance();
@@ -305,8 +312,8 @@ private:
     WireframeMode m_wireframe;
     bool m_textured; /* =true: textures are drawn as intended */
     bool m_coordAxis; /* =true: coord Axis will be drawn */
-    bool m_showMenu;
-    bool m_showObjects;
+    bool m_allowMenuOnly;
+    MenuVisibilityState m_menuState;
 
     osg::Matrix m_invBaseMatrix;
     osg::Matrix m_oldInvBaseMatrix;

--- a/src/OpenCOVER/cover/coVRTui.cpp
+++ b/src/OpenCOVER/cover/coVRTui.cpp
@@ -255,10 +255,9 @@ coVRTui::coVRTui()
     Freeze = new coTUIToggleButton("Stop headtracking", topContainer->getID());
     Wireframe = new coTUIToggleButton("Wireframe", topContainer->getID());
     ViewAll = new coTUIButton("View all", topContainer->getID());
-    Menu = new coTUIToggleButton("Hide menu", topContainer->getID());
+    Menu = new coTUIButton("Toggle menu", topContainer->getID());
     scaleLabel = new coTUILabel("Scale factor (log10)", topContainer->getID());
     ScaleSlider = new coTUIFloatSlider("ScaleFactor", topContainer->getID());
-    Menu->setState(false);
     debugLabel = new coTUILabel("Debug level", topContainer->getID());
     debugLevel = new coTUIEditIntField("DebugLevel", topContainer->getID());
 #ifndef NOFB
@@ -1405,7 +1404,7 @@ void coVRTui::tabletPressEvent(coTUIElement *tUIItem)
     }
     else if (tUIItem == Menu)
     {
-        VRSceneGraph::instance()->setMenu(false);
+        VRSceneGraph::instance()->toggleMenu();
     }
     else if ((tUIItem == panNav) || (tUIItem == driveNav))
     {
@@ -1480,10 +1479,6 @@ void coVRTui::tabletReleaseEvent(coTUIElement *tUIItem)
     else if (tUIItem == Wireframe)
     {
         VRSceneGraph::instance()->setWireframe(VRSceneGraph::Disabled);
-    }
-    else if (tUIItem == Menu)
-    {
-        VRSceneGraph::instance()->setMenu(true);
     }
     else if (tUIItem == Animate)
     {

--- a/src/OpenCOVER/cover/coVRTui.h
+++ b/src/OpenCOVER/cover/coVRTui.h
@@ -227,7 +227,7 @@ private:
     coTUIToggleButton *testImage;
     coTUIToggleButton *Freeze;
     coTUIToggleButton *Wireframe;
-    coTUIToggleButton *Menu;
+    coTUIButton *Menu;
     coTUIEditFloatField *posX;
     coTUIEditFloatField *posY;
     coTUIEditFloatField *posZ;


### PR DESCRIPTION
With the Config-Entry COVER.AllowMenuOnlyState one let Cover hide the objects and show the menu only. Useful for Powerwalls when the menus are hidden behind objects.