### PR TITLE
Compile fix for Qt 5.12.9

### DIFF
--- a/src/sys/mapeditor/CMakeLists.txt
+++ b/src/sys/mapeditor/CMakeLists.txt
@@ -24,6 +24,11 @@ INCLUDE_DIRECTORIES(
     covise
   )
 
+find_package(Qt5Core)
+find_package(QtWidgets)
+INCLUDE_DIRECTORIES("${Qt5Core_INCLUDE_DIRS}")
+INCLUDE_DIRECTORIES("${Qt5Widgets_INCLUDE_DIRS}")
+
 SET(MAPEDITOR_SOURCES
   widgets/MEUserInterface.cpp
   widgets/MEGraphicsView.cpp

--- a/src/sys/mapeditor/covise/MEMessageHandler.h
+++ b/src/sys/mapeditor/covise/MEMessageHandler.h
@@ -8,6 +8,7 @@
 #ifndef ME_MESSAGEHANDLER_H
 #define ME_MESSAGEHANDLER_H
 
+#include <QtGlobal>
 #include <QObject>
 #include <QStringList>
 #include <QSocketNotifier>

--- a/src/sys/mapeditor/nodes/MENode.h
+++ b/src/sys/mapeditor/nodes/MENode.h
@@ -8,6 +8,7 @@
 #ifndef ME_NODE_H
 #define ME_NODE_H
 
+#include <QtGlobal>
 #include <QGraphicsItem>
 #include <QGraphicsSvgItem>
 #include <QObject>


### PR DESCRIPTION
The compilation of covise on `tumbleweed` runs in compile errors with `qt`. The installed version is `5.12.9`.

One issue is that the macro `QT_VERSION` is not defined in `MEMessageHandler.h`. The resulting error message is:
```
[ 15%] Building CXX object src/sys/mapeditor/CMakeFiles/mapeditor.dir/covise/moc_MEMessageHandler.cpp.o
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp: In static member function ‘static void MEMessageHandler::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)’:
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp:78:54: error: expected type-specifier before ‘QSocketDescriptor’
   78 |         case 0: _t->dataReceived((*reinterpret_cast< QSocketDescriptor(*)>(_a[1])),(*reinterpret_cast< QSocketNotifier::Type(*)>(_a[2]))); break;
      |                                                      ^~~~~~~~~~~~~~~~~
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp:78:54: error: expected ‘>’ before ‘QSocketDescriptor’
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp:78:54: error: expected ‘(’ before ‘QSocketDescriptor’
   78 |         case 0: _t->dataReceived((*reinterpret_cast< QSocketDescriptor(*)>(_a[1])),(*reinterpret_cast< QSocketNotifier::Type(*)>(_a[2]))); break;
      |                                                      ^~~~~~~~~~~~~~~~~
      |                                                      (
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp:78:73: error: expected primary-expression before ‘)’ token
   78 |         case 0: _t->dataReceived((*reinterpret_cast< QSocketDescriptor(*)>(_a[1])),(*reinterpret_cast< QSocketNotifier::Type(*)>(_a[2]))); break;
      |                                                                         ^
/home/ati/sandbox/addLib/covise/chalinochromisopt/build.covise/src/sys/mapeditor/covise/moc_MEMessageHandler.cpp:78:54: error: ‘QSocketDescriptor’ was not declared in this scope
   78 |         case 0: _t->dataReceived((*reinterpret_cast< QSocketDescriptor(*)>(_a[1])),(*reinterpret_cast< QSocketNotifier::Type(*)>(_a[2]))); break;
      |                                                      ^~~~~~~~~~~~~~~~~
make[2]: *** [src/sys/mapeditor/CMakeFiles/mapeditor.dir/build.make:2397: src/sys/mapeditor/CMakeFiles/mapeditor.dir/covise/moc_MEMessageHandler.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:12349: src/sys/mapeditor/CMakeFiles/mapeditor.dir/all] Error 2
```
In my opinion the macro

https://github.com/hlrs-vis/covise/blob/9ae162f51be69826b8f3a6ffeee4cda48dcd9f5e/src/sys/mapeditor/covise/MEMessageHandler.h#L52-L56

can not be correctly evaluated, due to the missing definition. A possible fix is to add
```
#include <QtGlobal>
```

to the header and to insert an `include_directories()` statement

```
find_package(Qt5Core)
INCLUDE_DIRECTORIES("${Qt5Core_INCLUDE_DIRS}")
```

in `CMakeLists.txt`. I am not sure, if this is the cleanest solution to include `qt` headers, but it solves the issue.

A second error occurs when compiling the file `moc_MENode.cpp`:
```
[ 31%] Generating nodes/moc_MENode.cpp
/home/ati/sandbox/addLib/covise/src/sys/mapeditor/nodes/MENode.h:57: Error: Undefined interface
make[2]: *** [src/sys/mapeditor/CMakeFiles/mapeditor.dir/build.make:306: src/sys/mapeditor/nodes/moc_MENode.cpp] Error 1
```
I think, the `moc` compiler does not know the interface `QGraphicsItem`

https://github.com/hlrs-vis/covise/blob/9ae162f51be69826b8f3a6ffeee4cda48dcd9f5e/src/sys/mapeditor/nodes/MENode.h#L57

and again the `QT_VERSION` macro. The missing interface definition can be fixed by adding
```
find_package(QtWidgets)
INCLUDE_DIRECTORIES("${Qt5Widgets_INCLUDE_DIRS}")
```
to `CMakeLists.txt`; the missing macro is fixed as mentioned above.
