### PR TITLE
simplify computation of boundingSphere

### DIFF
--- a/src/OpenCOVER/cover/VRSceneGraph.cpp
+++ b/src/OpenCOVER/cover/VRSceneGraph.cpp
@@ -856,7 +856,7 @@ VRSceneGraph::update()
         }
         m_firstTime = false;
     }
-    
+
     if(!m_hidePointer->state())
     {
     if (Input::instance()->hasHand() && Input::instance()->isTrackingOn())
@@ -1416,60 +1416,7 @@ VRSceneGraph::getBoundingSphere()
 
     scaleNode->dirtyBound();
     //osg::BoundingSphere bsphere = coVRSelectionManager::instance()->getBoundingSphere(m_objectsRoot);
-    osg::BoundingSphere bsphere;
-
-    // determine center of bounding sphere
-    BoundingBox bb;
-    bb.init();
-    osg::Node *currentNode = NULL;
-    for (unsigned int i = 0; i < scaleNode->getNumChildren(); i++)
-    {
-        currentNode = scaleNode->getChild(i);
-        const osg::Transform *transform = currentNode->asTransform();
-        if ((!transform || transform->getReferenceFrame() == osg::Transform::RELATIVE_RF) && strncmp(currentNode->getName().c_str(), "Avatar ", 7) != 0)
-        {
-            // Using the Visitor from scaleNode doesn't work if it's m_scaleTransform (ScaleWithInteractors==true) -> therefore the loop)
-            NodeSet::iterator it = m_specialBoundsNodeList.find(currentNode);
-            if (it == m_specialBoundsNodeList.end())
-            {
-                osg::ComputeBoundsVisitor cbv;
-                cbv.setTraversalMask(Isect::Visible);
-                currentNode->accept(cbv);
-                bb.expandBy(cbv.getBoundingBox());
-            }
-            else
-            {
-                bb.expandBy(currentNode->getBound());
-            }
-        }
-    }
-
-    // determine radius of bounding sphere
-    if (bb.valid())
-    {
-        bsphere._center = bb.center();
-        bsphere._radius = 0.0f;
-        for (unsigned int i = 0; i < scaleNode->getNumChildren(); i++)
-        {
-            currentNode = scaleNode->getChild(i);
-            const osg::Transform *transform = currentNode->asTransform();
-            if ((!transform || transform->getReferenceFrame() == osg::Transform::RELATIVE_RF) && strncmp(currentNode->getName().c_str(), "Avatar ", 7) != 0)
-            {
-                NodeSet::iterator it = m_specialBoundsNodeList.find(currentNode);
-                if (it == m_specialBoundsNodeList.end())
-                {
-                    osg::ComputeBoundsVisitor cbv;
-                    cbv.setTraversalMask(Isect::Visible);
-                    currentNode->accept(cbv);
-                    bsphere.expandRadiusBy(cbv.getBoundingBox());
-                }
-                else
-                {
-                    bsphere.expandRadiusBy(currentNode->getBound());
-                }
-            }
-        }
-    }
+    auto bsphere = scaleNode->computeBound();
 
     m_scalingAllObjects = false;
 

--- a/src/OpenCOVER/cover/VRSceneGraph.h
+++ b/src/OpenCOVER/cover/VRSceneGraph.h
@@ -141,7 +141,7 @@ public:
     osg::StateSet *loadGlobalGeostate();
     osg::StateSet *loadUnlightedGeostate(osg::Material::ColorMode mode = osg::Material::OFF);
     osg::StateSet *loadTransparentGeostate(osg::Material::ColorMode mode = osg::Material::OFF);
-    osg::StateSet *loadDefaultPointstate(float pointSize = 4, osg::Material::ColorMode mode = osg::Material::OFF); 
+    osg::StateSet *loadDefaultPointstate(float pointSize = 4, osg::Material::ColorMode mode = osg::Material::OFF);
     void setWireframe(WireframeMode mode);
     void setPointerType(int pointerType);
     int getPointerType()
@@ -206,7 +206,7 @@ public:
         return m_scaleFactor;
     }
     void setScaleFactor(float scaleFactor, bool sync = true);
-    void scaleAllObjects(bool resetView = false);
+    void scaleAllObjects(bool resetView = false, bool simple = false);
     bool isScalingAllObjects() const
     {
         return m_scalingAllObjects;
@@ -217,7 +217,7 @@ public:
 
     void toggleAxis(bool state);
     void toggleHighQuality(bool state);
-    void viewAll(bool resetView = false);
+    void viewAll(bool resetView = false, bool simple = false);
     float floorHeight()
     {
         return m_floorHeight;

--- a/src/OpenCOVER/cover/coVRNavigationManager.cpp
+++ b/src/OpenCOVER/cover/coVRNavigationManager.cpp
@@ -411,7 +411,16 @@ void coVRNavigationManager::initMenu()
     m_viewAll->setPriority(ui::Element::Toolbar);
     m_viewAll->setIcon("zoom-fit-best");
 
-
+    m_viewVisible = new ui::Action(navMenu_, "ViewVisible");
+    m_viewVisible->setText("View visible");
+    m_viewVisible->setShortcut("Shift+Alt+V");
+    m_viewVisible->setCallback([this, protectNav](){
+        protectNav([](){
+            VRSceneGraph::instance()->viewAll(false, true);
+        });
+    });
+    m_viewVisible->setPriority(ui::Element::Toolbar);
+    m_viewVisible->setIcon("zoom-to-visible");
 
 
     centerViewButton = new ui::Action(navMenu_, "centerView");
@@ -1190,7 +1199,7 @@ coVRNavigationManager::update()
 			break;
 		}
 	}
-    
+
 
     // was ist wenn mehrere Objekte geladen sind???
 
@@ -2743,7 +2752,7 @@ void coVRNavigationManager::doWalkMoveToFloor()
 
     // do not sync with remote, they will do the same
     // on their side SyncXform();
-	
+
     // coVRCollaboration::instance()->SyncXform();
 }
 

--- a/src/OpenCOVER/cover/coVRNavigationManager.h
+++ b/src/OpenCOVER/cover/coVRNavigationManager.h
@@ -351,7 +351,7 @@ private:
     vrui::coRowMenu *nameMenu_;
     vrui::coButtonMenuItem *nameButton_;
     ui::Menu *navMenu_ = nullptr;
-    ui::Action *m_viewAll=nullptr, *m_resetView=nullptr;
+    ui::Action *m_viewAll=nullptr, *m_resetView=nullptr, *m_viewVisible=nullptr;
     ui::Group *navModes_ = nullptr;
     ui::ButtonGroup *navGroup_ = nullptr;
     ui::Button *noNavButton_=nullptr;
@@ -378,7 +378,7 @@ private:
     void initMenu();
     void initShowName();
     void initMeasure();
-    
+
     osg::Vec3 getCenter() const;
     void centerView();
     osg::Vec3 mouseNavCenter;

--- a/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.cpp
@@ -4,29 +4,28 @@
 #include <cstdint>
 
 CityGMLDeviceSensor::CityGMLDeviceSensor(
-    osg::ref_ptr<osg::Group> group,
+    osg::ref_ptr<osg::Group> parent,
     std::unique_ptr<core::interface::IInfoboard<std::string>> &&infoBoard,
     std::unique_ptr<core::interface::IBuilding> &&drawableBuilding)
-    : coPickSensor(group), m_cityGMLBuilding(std::move(drawableBuilding)),
+    : coPickSensor(parent), m_cityGMLBuilding(std::move(drawableBuilding)),
       m_infoBoard(std::move(infoBoard)) {
 
-  m_cityGMLBuilding->initDrawable();
+  m_cityGMLBuilding->initDrawables();
 
   // infoboard
   m_infoBoard->initInfoboard();
   m_infoBoard->initDrawable();
-  group->addChild(m_infoBoard->getDrawable());
+  parent->addChild(m_infoBoard->getDrawable());
 }
 
 CityGMLDeviceSensor::~CityGMLDeviceSensor() {
   if (m_active)
     disactivate();
-  auto parent = m_cityGMLBuilding->getDrawable()->getParent(0);
-  parent->removeChild(m_infoBoard->getDrawable());
+  getParent()->removeChild(m_infoBoard->getDrawable());
 }
 
 void CityGMLDeviceSensor::update() {
-  m_cityGMLBuilding->updateDrawable();
+  m_cityGMLBuilding->updateDrawables();
   m_infoBoard->updateDrawable();
   coPickSensor::update();
 }

--- a/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.cpp
@@ -1,15 +1,16 @@
 #include <CityGMLDeviceSensor.h>
 #include <PluginUtil/coSensor.h>
 #include <core/CityGMLBuilding.h>
+
 #include <cstdint>
 
 CityGMLDeviceSensor::CityGMLDeviceSensor(
     osg::ref_ptr<osg::Group> parent,
     std::unique_ptr<core::interface::IInfoboard<std::string>> &&infoBoard,
     std::unique_ptr<core::interface::IBuilding> &&drawableBuilding)
-    : coPickSensor(parent), m_cityGMLBuilding(std::move(drawableBuilding)),
+    : coPickSensor(parent),
+      m_cityGMLBuilding(std::move(drawableBuilding)),
       m_infoBoard(std::move(infoBoard)) {
-
   m_cityGMLBuilding->initDrawables();
 
   // infoboard
@@ -19,8 +20,7 @@ CityGMLDeviceSensor::CityGMLDeviceSensor(
 }
 
 CityGMLDeviceSensor::~CityGMLDeviceSensor() {
-  if (m_active)
-    disactivate();
+  if (m_active) disactivate();
   getParent()->removeChild(m_infoBoard->getDrawable());
 }
 
@@ -39,8 +39,7 @@ void CityGMLDeviceSensor::activate() {
 }
 
 void CityGMLDeviceSensor::disactivate() {
-  if (m_active)
-    return;
+  if (m_active) return;
   m_infoBoard->hideInfo();
 }
 
@@ -63,8 +62,7 @@ void CityGMLDeviceSensor::updateTime(int timestep) {
     b--;
   }
 
-  m_cityGMLBuilding->updateColor(
-      osg::Vec4(r / 255.0, g / 255.0, b / 255.0, 1.0));
+  m_cityGMLBuilding->updateColor(osg::Vec4(r / 255.0, g / 255.0, b / 255.0, 1.0));
   m_cityGMLBuilding->updateTime(timestep);
   m_infoBoard->updateTime(timestep);
 }

--- a/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.h
@@ -4,11 +4,12 @@
 #include <PluginUtil/coSensor.h>
 #include <core/interfaces/IBuilding.h>
 #include <core/interfaces/IInfoboard.h>
+
 #include <memory>
 #include <osg/Group>
 
 class CityGMLDeviceSensor : public coPickSensor {
-public:
+ public:
   CityGMLDeviceSensor(
       osg::ref_ptr<osg::Group> group,
       std::unique_ptr<core::interface::IInfoboard<std::string>> &&infoBoard,
@@ -26,12 +27,12 @@ public:
   }
 
   auto getDrawables() const { return m_cityGMLBuilding->getDrawables(); }
-  osg::Node* getDrawable(size_t index) const {
+  osg::Node *getDrawable(size_t index) const {
     return m_cityGMLBuilding->getDrawable(index);
   }
   auto getParent() { return getNode()->asGroup(); }
 
-private:
+ private:
   std::unique_ptr<core::interface::IBuilding> m_cityGMLBuilding;
   std::unique_ptr<core::interface::IInfoboard<std::string>> m_infoBoard;
   bool m_active = false;

--- a/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/CityGMLDeviceSensor.h
@@ -24,9 +24,12 @@ public:
   void updateColorOfBuilding(const osg::Vec4 &color) {
     m_cityGMLBuilding->updateColor(color);
   }
-  osg::Node* getDrawable() const {
-    return m_cityGMLBuilding->getDrawable();
+
+  auto getDrawables() const { return m_cityGMLBuilding->getDrawables(); }
+  osg::Node* getDrawable(size_t index) const {
+    return m_cityGMLBuilding->getDrawable(index);
   }
+  auto getParent() { return getNode()->asGroup(); }
 
 private:
   std::unique_ptr<core::interface::IBuilding> m_cityGMLBuilding;

--- a/src/OpenCOVER/plugins/hlrs/Energy/Device.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/Device.cpp
@@ -6,14 +6,15 @@
 * License: LGPL 2+ */
 
 #include "Device.h"
+
 #include <cover/coVRFileManager.h>
+
 #include <cstdio>
 #include <osg/Material>
 
 using namespace opencover;
 
 namespace energy {
-
 Device::Device(DeviceInfo::ptr d, osg::ref_ptr<osg::Group> parent) {
   myParent = parent;
   devInfo = d;
@@ -67,25 +68,22 @@ void Device::init(float r, float sH, int c) {
   osg::Vec4 colVecLimit(1.f, 1.f, 1.f, 1.f);
 
   auto setCyclAndColor = [&](const float &compVal) {
-    cyl->set(osg::Vec3(devInfo->lon, devInfo->lat,
-                       devInfo->height + compVal * sH / 2),
-             rad, -compVal * sH);
+    cyl->set(
+        osg::Vec3(devInfo->lon, devInfo->lat, devInfo->height + compVal * sH / 2),
+        rad, -compVal * sH);
     colVec = getColor(compVal, 1000.);
   };
 
   switch (c) {
-  case 0:
-    if (devInfo->strom > 0.)
-      setCyclAndColor(devInfo->strom);
-    break;
-  case 1:
-    if (devInfo->waerme > 0.)
-      setCyclAndColor(devInfo->waerme);
-    break;
-  case 2:
-    if (devInfo->kaelte > 0.)
-      setCyclAndColor(devInfo->kaelte);
-    break;
+    case 0:
+      if (devInfo->strom > 0.) setCyclAndColor(devInfo->strom);
+      break;
+    case 1:
+      if (devInfo->waerme > 0.) setCyclAndColor(devInfo->waerme);
+      break;
+    case 2:
+      if (devInfo->kaelte > 0.) setCyclAndColor(devInfo->kaelte);
+      break;
   }
   osg::ShapeDrawable *shapeD = new osg::ShapeDrawable(cyl);
 
@@ -165,18 +163,18 @@ void Device::showInfo() {
   std::string textvalues =
       (devInfo->baujahr > 0.f ? (std::to_string((int)devInfo->baujahr) + " \n")
                               : "- \n");
-  textvalues += (devInfo->flaeche > 0.f
-                     ? (std::to_string((int)devInfo->flaeche) + " m2 \n")
-                     : "- \n");
+  textvalues +=
+      (devInfo->flaeche > 0.f ? (std::to_string((int)devInfo->flaeche) + " m2 \n")
+                              : "- \n");
   textvalues +=
       (devInfo->strom < 0.f ? "- \n"
                             : (std::to_string((int)devInfo->strom) + " MW\n"));
-  textvalues += (devInfo->waerme < 0.f
-                     ? "- \n"
-                     : (std::to_string((int)devInfo->waerme) + " kW\n"));
-  textvalues += (devInfo->kaelte < 0.f
-                     ? "- \n"
-                     : (std::to_string((int)devInfo->kaelte) + " kW\n"));
+  textvalues +=
+      (devInfo->waerme < 0.f ? "- \n"
+                             : (std::to_string((int)devInfo->waerme) + " kW\n"));
+  textvalues +=
+      (devInfo->kaelte < 0.f ? "- \n"
+                             : (std::to_string((int)devInfo->kaelte) + " kW\n"));
 
   textBoxValues->setText(textvalues);
   textBoxValues->setCharacterSize(charSize);
@@ -199,8 +197,7 @@ void Device::showInfo() {
 
   osg::ref_ptr<osg::StateSet> textStateT = textBoxTitle->getOrCreateStateSet();
   textBoxTitle->setStateSet(textStateT);
-  osg::ref_ptr<osg::StateSet> textStateC =
-      textBoxContent->getOrCreateStateSet();
+  osg::ref_ptr<osg::StateSet> textStateC = textBoxContent->getOrCreateStateSet();
   textBoxContent->setStateSet(textStateC);
   osg::ref_ptr<osg::StateSet> textStateV = textBoxValues->getOrCreateStateSet();
   textBoxValues->setStateSet(textStateV);
@@ -218,4 +215,4 @@ void Device::showInfo() {
   TextGeode->addChild(matShift);
   BBoard->addChild(TextGeode);
 }
-} // namespace energy
+}  // namespace energy

--- a/src/OpenCOVER/plugins/hlrs/Energy/Device.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/Device.h
@@ -7,10 +7,10 @@
 #ifndef _Energy_Device_H
 #define _Energy_Device_H
 
+#include <cover/coBillboard.h>
 #include <cover/coVRPluginSupport.h>
 #include <util/common.h>
 
-#include <cover/coBillboard.h>
 #include <osg/Geode>
 #include <osg/Group>
 #include <osg/ShapeDrawable>
@@ -19,7 +19,7 @@
 namespace energy {
 
 struct DeviceInfo {
-public:
+ public:
   typedef std::shared_ptr<DeviceInfo> ptr;
   DeviceInfo(){};
   DeviceInfo(DeviceInfo &d) {
@@ -50,7 +50,7 @@ public:
 };
 
 class Device {
-public:
+ public:
   typedef std::shared_ptr<Device> ptr;
   Device(DeviceInfo::ptr d, osg::ref_ptr<osg::Group> parent);
   ~Device();
@@ -66,7 +66,7 @@ public:
   osg::ref_ptr<osg::Group> getGroup() { return deviceGroup; }
   const DeviceInfo::ptr getInfo() { return devInfo; }
 
-private:
+ private:
   DeviceInfo::ptr devInfo;
   osg::ref_ptr<osg::Group> myParent;
   osg::ref_ptr<osg::Group> TextGeode;
@@ -78,5 +78,5 @@ private:
   float rad;
   bool InfoVisible = false;
 };
-} // namespace energy
+}  // namespace energy
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/DeviceSensor.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/DeviceSensor.h
@@ -7,25 +7,26 @@
 #ifndef _Energy_DeviceSensor_H
 #define _Energy_DeviceSensor_H
 
-#include "Device.h"
 #include <PluginUtil/coSensor.h>
 #include <cover/coVRPluginSupport.h>
+
 #include <memory>
+
+#include "Device.h"
 
 using namespace opencover;
 
 namespace energy {
 class DeviceSensor : public coPickSensor {
-private:
+ private:
   energy::Device::ptr dev;
 
-public:
+ public:
   typedef std::shared_ptr<DeviceSensor> ptr;
   DeviceSensor(energy::Device::ptr d, osg::ref_ptr<osg::Node> n)
       : coPickSensor(n), dev(d){};
   ~DeviceSensor() {
-    if (active)
-      disactivate();
+    if (active) disactivate();
   }
   DeviceSensor(const DeviceSensor &other) = delete;
   DeviceSensor &operator=(const DeviceSensor &) = delete;
@@ -38,6 +39,6 @@ public:
   }
   energy::Device::ptr getDevice() const { return dev; }
 };
-} // namespace energy
+}  // namespace energy
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
@@ -114,9 +114,10 @@ private:
   void initEnnovatisUI();
   void initCityGMLUI();
   void enableCityGML(bool on);
-  void addCityGMLObjects(osg::MatrixTransform *node);
+  void addCityGMLObjects(osg::ref_ptr<osg::Group> grp);
+  void addCityGMLObject(const std::string &name, osg::ref_ptr<osg::Group> grp);
   void addCityGMLDefaultGeode(const std::string &name,
-                                      osg::ref_ptr<osg::Geode> geo);
+                              osg::ref_ptr<osg::Geode> geo);
   void restoreCityGMLDefault();
   void restoreCityGMLGeodesDefault(const std::string &name,
                            osg::ref_ptr<osg::Geode> geo);

--- a/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
@@ -21,6 +21,7 @@
 #include <EnnovatisDeviceSensor.h>
 #include <PluginUtil/coSensor.h>
 #include <core/PrototypeBuilding.h>
+#include <core/utils/osgUtils.h>
 #include <cover/VRViewer.h>
 #include <cover/coVRMSController.h>
 #include <cover/coVRPluginSupport.h>
@@ -79,6 +80,7 @@ class EnergyPlugin : public opencover::coVRPlugin,
   };
 
  private:
+  using Geodes = core::utils::osgUtils::Geodes;
   // typedef const ennovatis::Building *building_const_ptr;
   // typedef const ennovatis::Buildings *buildings_const_Ptr;
   typedef const ennovatis::Building *building_const_ptr;
@@ -106,12 +108,14 @@ class EnergyPlugin : public opencover::coVRPlugin,
   void initEnnovatisUI();
   void initCityGMLUI();
   void enableCityGML(bool on);
-  void addCityGMLObjects(osg::ref_ptr<osg::Group> grp);
-  void addCityGMLObject(const std::string &name, osg::ref_ptr<osg::Group> grp);
-  void addCityGMLDefaultGeode(const std::string &name, osg::ref_ptr<osg::Geode> geo);
-  void restoreCityGMLDefault();
-  void restoreCityGMLGeodesDefault(const std::string &name,
-                                   osg::ref_ptr<osg::Geode> geo);
+  void addCityGMLObjects(osg::ref_ptr<osg::Group> citygmlGroup);
+  void addCityGMLObject(const std::string &name,
+                        osg::ref_ptr<osg::Group> citygmlObjGroup);
+  void saveCityGMLObjectDefaultStateSet(const std::string &name,
+                                        const Geodes &citygmlGeodes);
+  void restoreCityGMLDefaultStatesets();
+  void restoreGeodesStatesets(CityGMLDeviceSensor &sensor, const std::string &name,
+                              const Geodes &citygmlGeodes);
   void selectEnabledDevice();
   void setEnnovatisChannelGrp(ennovatis::ChannelGroup group);
   void setRESTDate(const std::string &toSet, bool isFrom);
@@ -193,9 +197,8 @@ class EnergyPlugin : public opencover::coVRPlugin,
   osg::ref_ptr<osg::Sequence> m_sequenceList;
   osg::ref_ptr<osg::MatrixTransform> m_Energy;
   osg::ref_ptr<osg::Group> m_cityGML;
-  std::map<std::string, osg::ref_ptr<osg::Geode>> m_cityGMLDefault;
+  std::map<std::string, Geodes> m_cityGMLDefaultStatesets;
   std::map<std::string, std::unique_ptr<CityGMLDeviceSensor>> m_cityGMLObjs;
-  osg::Vec4 m_defaultColor;
 };
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/Energy.h
@@ -15,25 +15,15 @@
 #ifndef _Energy_PLUGIN_H
 #define _Energy_PLUGIN_H
 
-#include <map>
-#include <memory>
-#include <osg/Geode>
-#include <osg/Group>
-#include <osg/MatrixTransform>
-#include <osg/Node>
-#include <osg/Sequence>
-#include <osg/ref_ptr>
-#include <proj.h>
-#include <string>
-#include <util/common.h>
-
+#include <CityGMLDeviceSensor.h>
+#include <Device.h>
+#include <DeviceSensor.h>
+#include <EnnovatisDeviceSensor.h>
 #include <PluginUtil/coSensor.h>
+#include <core/PrototypeBuilding.h>
 #include <cover/VRViewer.h>
-#include <cover/coVRPluginSupport.h>
-
 #include <cover/coVRMSController.h>
 #include <cover/coVRPluginSupport.h>
-
 #include <cover/coVRTui.h>
 #include <cover/ui/Action.h>
 #include <cover/ui/Button.h>
@@ -42,21 +32,26 @@
 #include <cover/ui/Menu.h>
 #include <cover/ui/Owner.h>
 #include <cover/ui/SelectionList.h>
-#include <osg/Material>
-#include <osg/ShapeDrawable>
-#include <osg/Vec3>
-#include <util/coTypes.h>
-
-#include <gdal_priv.h>
-
-#include <CityGMLDeviceSensor.h>
-#include <Device.h>
-#include <DeviceSensor.h>
-#include <EnnovatisDeviceSensor.h>
-#include <core/PrototypeBuilding.h>
 #include <ennovatis/building.h>
 #include <ennovatis/rest.h>
+#include <gdal_priv.h>
+#include <proj.h>
+#include <util/coTypes.h>
+#include <util/common.h>
 #include <utils/read/csv/csv.h>
+
+#include <map>
+#include <memory>
+#include <osg/Geode>
+#include <osg/Group>
+#include <osg/Material>
+#include <osg/MatrixTransform>
+#include <osg/Node>
+#include <osg/Sequence>
+#include <osg/ShapeDrawable>
+#include <osg/Vec3>
+#include <osg/ref_ptr>
+#include <string>
 
 class EnergyPlugin : public opencover::coVRPlugin,
                      public opencover::ui::Owner,
@@ -67,7 +62,7 @@ class EnergyPlugin : public opencover::coVRPlugin,
     std::string projTo;
   };
 
-public:
+ public:
   EnergyPlugin();
   ~EnergyPlugin();
   EnergyPlugin(const EnergyPlugin &) = delete;
@@ -79,12 +74,11 @@ public:
   void setTimestep(int t);
   void setComponent(Components c);
   static EnergyPlugin *instance() {
-    if (!m_plugin)
-      m_plugin = new EnergyPlugin;
+    if (!m_plugin) m_plugin = new EnergyPlugin;
     return m_plugin;
   };
 
-private:
+ private:
   // typedef const ennovatis::Building *building_const_ptr;
   // typedef const ennovatis::Buildings *buildings_const_Ptr;
   typedef const ennovatis::Building *building_const_ptr;
@@ -94,8 +88,7 @@ private:
   // typedef std::vector<ennovatis::Building::ptr> const_buildings;
   // typedef std::map<energy::Device::ptr, ennovatis::Building::ptr>
   // DeviceBuildingMap;
-  typedef std::map<std::string, std::vector<energy::DeviceSensor::ptr>>
-      DeviceList;
+  typedef std::map<std::string, std::vector<energy::DeviceSensor::ptr>> DeviceList;
 
   void helper_initTimestepGrp(size_t maxTimesteps,
                               osg::ref_ptr<osg::Group> &timestepGroup);
@@ -104,10 +97,9 @@ private:
   void helper_projTransformation(bool mapdrape, PJ *P, PJ_COORD &coord,
                                  energy::DeviceInfo::ptr deviceInfoPtr,
                                  const double &lat, const double &lon);
-  void
-  helper_handleEnergyInfo(size_t maxTimesteps, int minYear,
-                          const opencover::utils::read::CSVStream::CSVRow &row,
-                          energy::DeviceInfo::ptr deviceInfoPtr);
+  void helper_handleEnergyInfo(size_t maxTimesteps, int minYear,
+                               const opencover::utils::read::CSVStream::CSVRow &row,
+                               energy::DeviceInfo::ptr deviceInfoPtr);
   bool loadDBFile(const std::string &fileName, const ProjTrans &projTrans);
   bool loadDB(const std::string &path, const ProjTrans &projTrans);
   void initRESTRequest();
@@ -116,11 +108,10 @@ private:
   void enableCityGML(bool on);
   void addCityGMLObjects(osg::ref_ptr<osg::Group> grp);
   void addCityGMLObject(const std::string &name, osg::ref_ptr<osg::Group> grp);
-  void addCityGMLDefaultGeode(const std::string &name,
-                              osg::ref_ptr<osg::Geode> geo);
+  void addCityGMLDefaultGeode(const std::string &name, osg::ref_ptr<osg::Geode> geo);
   void restoreCityGMLDefault();
   void restoreCityGMLGeodesDefault(const std::string &name,
-                           osg::ref_ptr<osg::Geode> geo);
+                                   osg::ref_ptr<osg::Geode> geo);
   void selectEnabledDevice();
   void setEnnovatisChannelGrp(ennovatis::ChannelGroup group);
   void setRESTDate(const std::string &toSet, bool isFrom);
@@ -137,8 +128,7 @@ private:
    * for REST-calls.
    * @return True if the data was successfully loaded, false otherwise.
    */
-  bool loadChannelIDs(const std::string &pathToJSON,
-                      const std::string &pathToCSV);
+  bool loadChannelIDs(const std::string &pathToJSON, const std::string &pathToCSV);
   bool updateChannelIDsFromCSV(const std::string &pathToCSV);
   core::CylinderAttributes getCylinderAttributes();
 
@@ -153,8 +143,8 @@ private:
    * @param deviceList The list of devices. Make sure map is sorted.
    * @return A unique pointer to buildings which have ne matching device.
    */
-  std::unique_ptr<const_buildings>
-  updateEnnovatisBuildings(const DeviceList &deviceList);
+  std::unique_ptr<const_buildings> updateEnnovatisBuildings(
+      const DeviceList &deviceList);
   // std::unique_ptr<ennovatis::Buildings> updateEnnovatisBuildings(const
   // DeviceList &deviceList);
 

--- a/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDevice.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDevice.cpp
@@ -134,8 +134,9 @@ void EnnovatisDevice::init() {
   m_deviceGroup->addChild(m_infoBoard->getDrawable());
 
   // cylinder / building representation
-  m_drawableBuilding->initDrawable();
-  m_deviceGroup->addChild(m_drawableBuilding->getDrawable());
+  m_drawableBuilding->initDrawables();
+  for (auto drawable : m_drawableBuilding->getDrawables())
+    m_deviceGroup->addChild(drawable);
 }
 
 void EnnovatisDevice::updateColorByTime(int timestep) {
@@ -185,9 +186,10 @@ void EnnovatisDevice::disactivate() {
     m_InfoVisible = false;
     m_infoBoard->hideInfo();
     // reset to default
-    m_deviceGroup->removeChild(m_drawableBuilding->getDrawable());
-    m_drawableBuilding->initDrawable();
-    m_deviceGroup->addChild(m_drawableBuilding->getDrawable());
+    for (auto drawable : m_drawableBuilding->getDrawables())
+      m_deviceGroup->removeChild(drawable);
+
+    m_drawableBuilding->initDrawables();
     m_timestepColors.clear();
   }
 }

--- a/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDevice.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDevice.h
@@ -6,14 +6,14 @@
 #include "core/interfaces/IInfoboard.h"
 
 // ennovatis
-#include "ennovatis/building.h"
-#include "ennovatis/json.h"
-#include "ennovatis/rest.h"
+#include <ennovatis/building.h>
+#include <ennovatis/json.h>
+#include <ennovatis/rest.h>
 
 // cover
-#include "cover/coVRMSController.h"
-#include "cover/ui/SelectionList.h"
 #include <cover/coBillboard.h>
+#include <cover/coVRMSController.h>
+#include <cover/ui/SelectionList.h>
 
 // osg
 #include <osg/Geode>
@@ -28,10 +28,9 @@
 #include <memory>
 
 class EnnovatisDevice {
-public:
+ public:
   EnnovatisDevice(
-      const ennovatis::Building &building,
-      opencover::ui::SelectionList *channelList,
+      const ennovatis::Building &building, opencover::ui::SelectionList *channelList,
       std::shared_ptr<ennovatis::rest_request> req,
       std::shared_ptr<ennovatis::ChannelGroup> channelGroup,
       std::unique_ptr<core::interface::IInfoboard<std::string>> &&infoBoard,
@@ -43,11 +42,9 @@ public:
   void setChannelGroup(std::shared_ptr<ennovatis::ChannelGroup> group);
   void setTimestep(int timestep) { updateColorByTime(timestep); }
   [[nodiscard]] const auto &getBuildingInfo() const { return m_buildingInfo; }
-  [[nodiscard]] osg::ref_ptr<osg::Group> getDeviceGroup() {
-    return m_deviceGroup;
-  }
+  [[nodiscard]] osg::ref_ptr<osg::Group> getDeviceGroup() { return m_deviceGroup; }
 
-private:
+ private:
   struct BuildingInfo {
     BuildingInfo(const ennovatis::Building *b) : building(b) {}
     const ennovatis::Building *building;
@@ -61,8 +58,7 @@ private:
   void updateChannelSelectionList();
   void setChannel(int idx);
   void updateColorByTime(int timestep);
-  void
-  createTimestepColorList(const ennovatis::json_response_object &j_resp_obj);
+  void createTimestepColorList(const ennovatis::json_response_object &j_resp_obj);
   void updateInfoboard(const std::string &info);
   [[nodiscard]] auto createBillboardTxt();
   [[nodiscard]] int getSelectedChannelIdx() const;
@@ -77,8 +73,8 @@ private:
   bool m_InfoVisible = false;
   BuildingInfo m_buildingInfo;
   ennovatis::rest_request_handler m_restWorker;
-  opencover::coVRMSController *m_opncvrCtrl; // cannot be const because syncing
-                                             // methods are not const correct
+  opencover::coVRMSController *m_opncvrCtrl;  // cannot be const because syncing
+                                              // methods are not const correct
   TimestepColorList m_timestepColors;
 };
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDeviceSensor.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDeviceSensor.cpp
@@ -1,4 +1,5 @@
 #include "EnnovatisDeviceSensor.h"
+
 #include <algorithm>
 
 void EnnovatisDeviceSensor::activate() {
@@ -11,8 +12,7 @@ void EnnovatisDeviceSensor::activate() {
 }
 
 void EnnovatisDeviceSensor::disactivate() {
-  if (m_activated)
-    return;
+  if (m_activated) return;
 
   m_dev->disactivate();
   auto selList = m_enabledDevices->items();

--- a/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDeviceSensor.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/EnnovatisDeviceSensor.h
@@ -1,20 +1,21 @@
 #ifndef _ENNOVATISDEVICESENSOR_H
 #define _ENNOVATISDEVICESENSOR_H
 
-#include "EnnovatisDevice.h"
-#include "cover/ui/SelectionList.h"
 #include <PluginUtil/coSensor.h>
+
 #include <memory>
 
+#include "EnnovatisDevice.h"
+#include "cover/ui/SelectionList.h"
+
 class EnnovatisDeviceSensor : public coPickSensor {
-public:
+ public:
   EnnovatisDeviceSensor(std::unique_ptr<EnnovatisDevice> d, osg::Group *n,
                         opencover::ui::SelectionList *selList)
       : coPickSensor(n), m_dev(std::move(d)), m_enabledDevices(selList) {}
 
   ~EnnovatisDeviceSensor() {
-    if (active)
-      disactivate();
+    if (active) disactivate();
   }
 
   [[nodiscard]] auto getDevice() const { return m_dev.get(); }
@@ -28,7 +29,7 @@ public:
   void activate() override;
   void disactivate() override;
 
-private:
+ private:
   opencover::ui::SelectionList *m_enabledDevices;
   std::unique_ptr<EnnovatisDevice> m_dev;
   bool m_activated = false;

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/CMakeLists.txt
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/CMakeLists.txt
@@ -11,10 +11,11 @@ set(HEADERS
     interfaces/IBuilding.h
     interfaces/IColorable.h
     interfaces/IDrawable.h
+    interfaces/IDrawables.h
     interfaces/IInfoboard.h
     interfaces/IInformable.h
     interfaces/IMovable.h
-    interfaces/ISeperable.h
+    interfaces/ISeparable.h
     interfaces/ITimedependable.h
     utils/color.h
     utils/osgUtils.h

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.cpp
@@ -4,19 +4,26 @@
 #include <osg/MatrixTransform>
 
 namespace core {
+using namespace utils;
 
-CityGMLBuilding::CityGMLBuilding(osg::Geode *geode) { m_drawable = geode; }
+CityGMLBuilding::CityGMLBuilding(
+    const osgUtils::Geodes &geodes) {
+  m_drawables.reserve(geodes.size());
+  m_drawables.insert(m_drawables.begin(), geodes.begin(), geodes.end());
+}
 
-void CityGMLBuilding::initDrawable() {}
+void CityGMLBuilding::initDrawables() {}
 
 void CityGMLBuilding::updateColor(const osg::Vec4 &color) {
-  if (auto geode = dynamic_cast<osg::Geode *>(m_drawable.get()))
-    utils::color::overrideGeodeColor(geode, color);
+    for (auto drawable : m_drawables) {
+        if (auto geo = drawable->asGeode())
+            color::overrideGeodeColor(geo, color);
+    }
 }
 
 void CityGMLBuilding::updateTime(int timestep) { m_timestep = timestep; }
 
-void CityGMLBuilding::updateDrawable() {}
+void CityGMLBuilding::updateDrawables() {}
 std::unique_ptr<osg::Vec4> CityGMLBuilding::getColorInRange(float value,
                                                             float maxValue) {
   return nullptr;

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.cpp
@@ -1,13 +1,14 @@
 #include "CityGMLBuilding.h"
-#include "utils/color.h"
+
 #include <osg/Geode>
 #include <osg/MatrixTransform>
+
+#include "utils/color.h"
 
 namespace core {
 using namespace utils;
 
-CityGMLBuilding::CityGMLBuilding(
-    const osgUtils::Geodes &geodes) {
+CityGMLBuilding::CityGMLBuilding(const osgUtils::Geodes &geodes) {
   m_drawables.reserve(geodes.size());
   m_drawables.insert(m_drawables.begin(), geodes.begin(), geodes.end());
 }
@@ -15,10 +16,9 @@ CityGMLBuilding::CityGMLBuilding(
 void CityGMLBuilding::initDrawables() {}
 
 void CityGMLBuilding::updateColor(const osg::Vec4 &color) {
-    for (auto drawable : m_drawables) {
-        if (auto geo = drawable->asGeode())
-            color::overrideGeodeColor(geo, color);
-    }
+  for (auto drawable : m_drawables) {
+    if (auto geo = drawable->asGeode()) color::overrideGeodeColor(geo, color);
+  }
 }
 
 void CityGMLBuilding::updateTime(int timestep) { m_timestep = timestep; }
@@ -28,4 +28,4 @@ std::unique_ptr<osg::Vec4> CityGMLBuilding::getColorInRange(float value,
                                                             float maxValue) {
   return nullptr;
 }
-} // namespace core
+}  // namespace core

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.h
@@ -7,14 +7,13 @@
 namespace core {
 
 class CityGMLBuilding : public interface::IBuilding {
-public:
+ public:
   CityGMLBuilding(const utils::osgUtils::Geodes &geodes);
   void initDrawables() override;
   void updateColor(const osg::Vec4 &color) override;
   void updateTime(int timestep) override;
   void updateDrawables() override;
-  std::unique_ptr<osg::Vec4> getColorInRange(float value,
-                                             float maxValue) override;
+  std::unique_ptr<osg::Vec4> getColorInRange(float value, float maxValue) override;
 };
-} // namespace core
+}  // namespace core
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/CityGMLBuilding.h
@@ -2,16 +2,17 @@
 #define _CORE_CITYGMLBUILDING_H
 
 #include "interfaces/IBuilding.h"
+#include "utils/osgUtils.h"
 
 namespace core {
 
 class CityGMLBuilding : public interface::IBuilding {
 public:
-  CityGMLBuilding(osg::Geode *geode);
-  void initDrawable() override;
+  CityGMLBuilding(const utils::osgUtils::Geodes &geodes);
+  void initDrawables() override;
   void updateColor(const osg::Vec4 &color) override;
   void updateTime(int timestep) override;
-  void updateDrawable() override;
+  void updateDrawables() override;
   std::unique_ptr<osg::Vec4> getColorInRange(float value,
                                              float maxValue) override;
 };

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.cpp
@@ -1,8 +1,10 @@
-#include "osg/ref_ptr"
 #include <PrototypeBuilding.h>
-#include <memory>
 #include <utils/color.h>
 #include <utils/osgUtils.h>
+
+#include <memory>
+
+#include "osg/ref_ptr"
 
 namespace core {
 
@@ -24,7 +26,7 @@ auto PrototypeBuilding::getColor(float val, float max) const {
 void PrototypeBuilding::updateColor(const osg::Vec4 &color) {
   for (auto drawable : m_drawables)
     if (auto geode = dynamic_cast<osg::Geode *>(drawable.get()))
-        utils::color::overrideGeodeColor(geode, color);
+      utils::color::overrideGeodeColor(geode, color);
 }
 
 void PrototypeBuilding::initDrawables() {
@@ -44,7 +46,8 @@ std::unique_ptr<osg::Vec4> PrototypeBuilding::getColorInRange(float value,
 void PrototypeBuilding::updateDrawables() {}
 
 void PrototypeBuilding::updateTime(int timestep) {
-  // TODO: update for example the height of the cylinder with each timestep
+  // TODO: update for example the height of the cylinder with each
+  // timestep
 }
 
-} // namespace core
+}  // namespace core

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.cpp
@@ -1,3 +1,4 @@
+#include "osg/ref_ptr"
 #include <PrototypeBuilding.h>
 #include <memory>
 #include <utils/color.h>
@@ -21,17 +22,18 @@ auto PrototypeBuilding::getColor(float val, float max) const {
 }
 
 void PrototypeBuilding::updateColor(const osg::Vec4 &color) {
-  if (auto geode = dynamic_cast<osg::Geode *>(m_drawable.get()))
-    utils::color::overrideGeodeColor(geode, color);
+  for (auto drawable : m_drawables)
+    if (auto geode = dynamic_cast<osg::Geode *>(drawable.get()))
+        utils::color::overrideGeodeColor(geode, color);
 }
 
-void PrototypeBuilding::initDrawable() {
-  m_drawable = new osg::Geode;
+void PrototypeBuilding::initDrawables() {
   const osg::Vec3f bottom(m_attributes.position);
   osg::Vec3f top(bottom);
   top.z() += m_attributes.height;
-  m_drawable = utils::osgUtils::createCylinderBetweenPoints(
+  osg::ref_ptr<osg::Geode> drawable = utils::osgUtils::createCylinderBetweenPoints(
       bottom, top, m_attributes.radius, m_attributes.colorMap.defaultColor);
+  m_drawables.push_back(drawable);
 }
 
 std::unique_ptr<osg::Vec4> PrototypeBuilding::getColorInRange(float value,
@@ -39,7 +41,7 @@ std::unique_ptr<osg::Vec4> PrototypeBuilding::getColorInRange(float value,
   return getColor(value, maxValue);
 }
 
-void PrototypeBuilding::updateDrawable() {}
+void PrototypeBuilding::updateDrawables() {}
 
 void PrototypeBuilding::updateTime(int timestep) {
   // TODO: update for example the height of the cylinder with each timestep

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.h
@@ -1,27 +1,26 @@
 #ifndef _CORE_PROTOTYPEBUILDING_H
 #define _CORE_PROTOTYPEBUILDING_H
 
-#include "interfaces/IBuilding.h"
-#include "utils/color.h"
 #include <memory>
 #include <osg/Vec3>
 #include <osg/Vec4>
+
+#include "interfaces/IBuilding.h"
+#include "utils/color.h"
 
 namespace core {
 
 struct CylinderAttributes {
   using ColorMap = utils::color::ColorMap;
-  CylinderAttributes(const float &rad, const float &height,
-                     const osg::Vec3 &pos, const ColorMap &colorMap)
+  CylinderAttributes(const float &rad, const float &height, const osg::Vec3 &pos,
+                     const ColorMap &colorMap)
       : radius(rad), height(height), position(pos), colorMap(colorMap) {}
-  CylinderAttributes(const float &rad, const float &height,
-                     const osg::Vec4 &maxCol, const osg::Vec4 &minCol,
-                     const osg::Vec3 &pos, const osg::Vec4 &defaultCol)
-      : CylinderAttributes(rad, height, pos,
-                           ColorMap(maxCol, minCol, defaultCol)) {}
-  CylinderAttributes(const float &rad, const float &height,
-                     const osg::Vec4 &maxCol, const osg::Vec4 &minCol,
+  CylinderAttributes(const float &rad, const float &height, const osg::Vec4 &maxCol,
+                     const osg::Vec4 &minCol, const osg::Vec3 &pos,
                      const osg::Vec4 &defaultCol)
+      : CylinderAttributes(rad, height, pos, ColorMap(maxCol, minCol, defaultCol)) {}
+  CylinderAttributes(const float &rad, const float &height, const osg::Vec4 &maxCol,
+                     const osg::Vec4 &minCol, const osg::Vec4 &defaultCol)
       : CylinderAttributes(rad, height, osg::Vec3(0, 0, 0),
                            ColorMap(maxCol, minCol, defaultCol)) {}
   float radius;
@@ -31,21 +30,20 @@ struct CylinderAttributes {
 };
 
 class PrototypeBuilding : public interface::IBuilding {
-public:
+ public:
   PrototypeBuilding(const CylinderAttributes &cylinderAttributes)
       : m_attributes(cylinderAttributes){};
   void initDrawables() override;
   void updateColor(const osg::Vec4 &color) override;
   void updateTime(int timestep) override;
   void updateDrawables() override;
-  std::unique_ptr<osg::Vec4> getColorInRange(float value,
-                                             float maxValue) override;
+  std::unique_ptr<osg::Vec4> getColorInRange(float value, float maxValue) override;
 
-private:
+ private:
   auto getColor(float val, float max) const;
 
   CylinderAttributes m_attributes;
 };
-} // namespace core
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/PrototypeBuilding.h
@@ -34,10 +34,10 @@ class PrototypeBuilding : public interface::IBuilding {
 public:
   PrototypeBuilding(const CylinderAttributes &cylinderAttributes)
       : m_attributes(cylinderAttributes){};
-  void initDrawable() override;
+  void initDrawables() override;
   void updateColor(const osg::Vec4 &color) override;
   void updateTime(int timestep) override;
-  void updateDrawable() override;
+  void updateDrawables() override;
   std::unique_ptr<osg::Vec4> getColorInRange(float value,
                                              float maxValue) override;
 

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.cpp
@@ -1,6 +1,5 @@
 #include "TxtInfoboard.h"
-#include "cover/coBillboard.h"
-#include "utils/osgUtils.h"
+
 #include <cover/coVRFileManager.h>
 
 #include <osg/Geode>
@@ -8,6 +7,9 @@
 #include <osg/Vec3>
 #include <osg/ref_ptr>
 #include <osgText/Text>
+
+#include "cover/coBillboard.h"
+#include "utils/osgUtils.h"
 
 namespace core {
 
@@ -40,13 +42,12 @@ void TxtInfoboard::updateInfo(const std::string &info) {
   auto contentPos = pos;
   contentPos.z() -= m_attributes.height * m_attributes.titleHeightPercentage;
 
-  auto textBoxTitle =
-      createTextBox(m_attributes.title, pos, m_attributes.charSize,
-                    m_attributes.fontFile.c_str(), m_attributes.maxWidth,
-                    m_attributes.margin);
-  auto textBoxContent = createTextBox(
-      "", contentPos, m_attributes.charSize, m_attributes.fontFile.c_str(),
-      m_attributes.maxWidth, m_attributes.margin);
+  auto textBoxTitle = createTextBox(m_attributes.title, pos, m_attributes.charSize,
+                                    m_attributes.fontFile.c_str(),
+                                    m_attributes.maxWidth, m_attributes.margin);
+  auto textBoxContent = createTextBox("", contentPos, m_attributes.charSize,
+                                      m_attributes.fontFile.c_str(),
+                                      m_attributes.maxWidth, m_attributes.margin);
   textBoxContent->setText(info, osgText::String::ENCODING_UTF8);
 
   osg::ref_ptr<osg::Geode> geo = new osg::Geode();
@@ -57,8 +58,7 @@ void TxtInfoboard::updateInfo(const std::string &info) {
   m_TextGeode = new osg::Group();
   m_TextGeode->setName("TextGroup");
   m_TextGeode->addChild(geo);
-  if (m_enabled)
-    showInfo();
+  if (m_enabled) showInfo();
 }
 
 void TxtInfoboard::showInfo() {
@@ -68,8 +68,7 @@ void TxtInfoboard::showInfo() {
 
 void TxtInfoboard::move(const osg::Vec3 &pos) {
   m_attributes.position = pos;
-  if (m_enabled)
-    updateInfo(m_info);
+  if (m_enabled) updateInfo(m_info);
 }
 
 void TxtInfoboard::hideInfo() {
@@ -77,18 +76,16 @@ void TxtInfoboard::hideInfo() {
   m_enabled = false;
 }
 
-osg::ref_ptr<osgText::Text>
-TxtInfoboard::createTextBox(const std::string &text, const osg::Vec3 &position,
-                            int charSize, const char *fontFile,
-                            const float &maxWidth, const float &margin) const {
+osg::ref_ptr<osgText::Text> TxtInfoboard::createTextBox(
+    const std::string &text, const osg::Vec3 &position, int charSize,
+    const char *fontFile, const float &maxWidth, const float &margin) const {
   osg::ref_ptr<osgText::Text> textBox = new osgText::Text();
   textBox->setAlignment(osgText::Text::LEFT_TOP);
   textBox->setAxisAlignment(osgText::Text::XZ_PLANE);
   textBox->setColor(osg::Vec4(1, 1, 1, 1));
   textBox->setText(text, osgText::String::ENCODING_UTF8);
   textBox->setCharacterSize(charSize);
-  textBox->setFont(
-      opencover::coVRFileManager::instance()->getFontFile(fontFile));
+  textBox->setFont(opencover::coVRFileManager::instance()->getFontFile(fontFile));
   textBox->setMaximumWidth(maxWidth);
   textBox->setPosition(position);
   textBox->setDrawMode(osgText::Text::FILLEDBOUNDINGBOX | osgText::Text::TEXT);
@@ -96,4 +93,4 @@ TxtInfoboard::createTextBox(const std::string &text, const osg::Vec3 &position,
   textBox->setBoundingBoxMargin(margin);
   return textBox;
 }
-} // namespace core
+}  // namespace core

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.cpp
@@ -19,6 +19,7 @@ void TxtInfoboard::initDrawable() {
   osg::ref_ptr<osg::MatrixTransform> trans = new osg::MatrixTransform;
   trans->setMatrix(osg::Matrix::translate(m_attributes.position));
   trans->addChild(m_BBoard);
+  trans->setName("Billboard");
   m_drawable = trans;
 }
 

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/TxtInfoboard.h
@@ -1,39 +1,45 @@
 #ifndef _CORE_TXTINFOBOARD_H
 #define _CORE_TXTINFOBOARD_H
 
-#include "interfaces/IInfoboard.h"
 #include <cover/coBillboard.h>
+
 #include <osg/ref_ptr>
 #include <osgText/Text>
+
+#include "interfaces/IInfoboard.h"
 
 namespace core {
 struct TxtBoxAttributes {
   TxtBoxAttributes(const osg::Vec3 &pos, const std::string &title,
-                   const std::string &font, const float &width,
-                   const float &height, const float &margin,
-                   const float &titleHeightPercentage, int charSize = 2)
-      : position(pos), title(title), fontFile(font), maxWidth(width),
-        height(height), margin(margin),
-        titleHeightPercentage(titleHeightPercentage), charSize(charSize) {}
+                   const std::string &font, const float &width, const float &height,
+                   const float &margin, const float &titleHeightPercentage,
+                   int charSize = 2)
+      : position(pos),
+        title(title),
+        fontFile(font),
+        maxWidth(width),
+        height(height),
+        margin(margin),
+        titleHeightPercentage(titleHeightPercentage),
+        charSize(charSize) {}
   osg::Vec3 position;
   std::string title;
   std::string fontFile;
   float maxWidth;
   float height;
   float margin;
-  float titleHeightPercentage; // title height in percentage of total height
+  float titleHeightPercentage;  // title height in percentage of total height
   int charSize;
 };
 class TxtInfoboard : public interface::IInfoboard<std::string> {
-public:
+ public:
   TxtInfoboard(const TxtBoxAttributes &attributes) : m_attributes(attributes){};
   TxtInfoboard(const osg::Vec3 &position, const std::string &title,
-               const std::string &font, const float &maxWidth,
-               const float &height, const float &margin,
-               const float &titleHeightPercentage, int charSize = 2)
+               const std::string &font, const float &maxWidth, const float &height,
+               const float &margin, const float &titleHeightPercentage,
+               int charSize = 2)
       : m_attributes(TxtBoxAttributes(position, title, font, maxWidth, height,
-                                      margin, titleHeightPercentage,
-                                      charSize)){};
+                                      margin, titleHeightPercentage, charSize)){};
 
   // IInfoboard interface
   void updateTime(int timestep) override;
@@ -54,9 +60,7 @@ public:
   [[nodiscard]] const auto &getMaxWidth(float width) {
     return m_attributes.maxWidth;
   }
-  [[nodiscard]] const auto &getHeight(float height) {
-    return m_attributes.height;
-  }
+  [[nodiscard]] const auto &getHeight(float height) { return m_attributes.height; }
   [[nodiscard]] const auto &getFont(const std::string &font) {
     return m_attributes.fontFile;
   }
@@ -67,10 +71,10 @@ public:
     return m_attributes.charSize;
   }
 
-private:
+ private:
   osg::ref_ptr<osgText::Text> createTextBox(const std::string &text,
-                                            const osg::Vec3 &position,
-                                            int charSize, const char *fontFile,
+                                            const osg::Vec3 &position, int charSize,
+                                            const char *fontFile,
                                             const float &maxWidth,
                                             const float &margin) const;
   osg::ref_ptr<osg::Group> m_TextGeode = nullptr;
@@ -79,6 +83,6 @@ private:
   // txtbox attributes
   TxtBoxAttributes m_attributes;
 };
-} // namespace core
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IBuilding.h
@@ -2,14 +2,13 @@
 #define _CORE_INTERFACES_IBUILDING_H
 
 #include "IColorable.h"
-#include "IDrawable.h"
+#include "IDrawables.h"
 #include "ITimedependable.h"
 #include <memory>
 #include <osg/Vec4>
 
-namespace core {
-namespace interface {
-class IBuilding : public IDrawable, public IColorable, public ITimedependable {
+namespace core::interface {
+class IBuilding : public IDrawables, public IColorable, public ITimedependable {
 public:
   /**
    * Returns the color in the range [0, maxValue] based on the given value based
@@ -22,7 +21,6 @@ public:
   virtual std::unique_ptr<osg::Vec4> getColorInRange(float value,
                                                      float maxValue) = 0;
 };
-} // namespace interface
-} // namespace core
+} // namespace interface::core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IBuilding.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IBuilding.h
@@ -1,15 +1,16 @@
 #ifndef _CORE_INTERFACES_IBUILDING_H
 #define _CORE_INTERFACES_IBUILDING_H
 
-#include "IColorable.h"
-#include "IDrawables.h"
-#include "ITimedependable.h"
 #include <memory>
 #include <osg/Vec4>
 
+#include "IColorable.h"
+#include "IDrawables.h"
+#include "ITimedependable.h"
+
 namespace core::interface {
 class IBuilding : public IDrawables, public IColorable, public ITimedependable {
-public:
+ public:
   /**
    * Returns the color in the range [0, maxValue] based on the given value based
    * on colorRange of building instance.
@@ -21,6 +22,6 @@ public:
   virtual std::unique_ptr<osg::Vec4> getColorInRange(float value,
                                                      float maxValue) = 0;
 };
-} // namespace interface::core
+}  // namespace core::interface
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IColorable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IColorable.h
@@ -6,10 +6,10 @@
 namespace core {
 namespace interface {
 class IColorable {
-public:
+ public:
   virtual void updateColor(const osg::Vec4 &color) = 0;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawable.h
@@ -7,15 +7,15 @@
 namespace core {
 namespace interface {
 class IDrawable {
-public:
+ public:
   virtual void initDrawable() = 0;
   virtual void updateDrawable() = 0;
   auto getDrawable() { return m_drawable; }
 
-protected:
+ protected:
   osg::ref_ptr<osg::Node> m_drawable;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawables.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawables.h
@@ -5,15 +5,15 @@
 
 namespace core::interface {
 class IDrawables {
-public:
+ public:
   virtual void initDrawables() = 0;
   virtual void updateDrawables() = 0;
   auto getDrawables() { return m_drawables; }
   auto getDrawable(size_t index) { return m_drawables.at(index); }
 
-protected:
+ protected:
   std::vector<osg::ref_ptr<osg::Node>> m_drawables;
 };
-} // namespace core
+}  // namespace core::interface
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawables.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IDrawables.h
@@ -1,0 +1,19 @@
+#ifndef _CORE_INTERFACES_IDRAWABLES_H
+#define _CORE_INTERFACES_IDRAWABLES_H
+
+#include <osg/Node>
+
+namespace core::interface {
+class IDrawables {
+public:
+  virtual void initDrawables() = 0;
+  virtual void updateDrawables() = 0;
+  auto getDrawables() { return m_drawables; }
+  auto getDrawable(size_t index) { return m_drawables.at(index); }
+
+protected:
+  std::vector<osg::ref_ptr<osg::Node>> m_drawables;
+};
+} // namespace core
+
+#endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IInfoboard.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IInfoboard.h
@@ -1,22 +1,24 @@
 #ifndef _CORE_INTERFACES_IINFOBOARD_H
 #define _CORE_INTERFACES_IINFOBOARD_H
 
-#include "ITimedependable.h"
 #include "IInformable.h"
 #include "IMovable.h"
+#include "ITimedependable.h"
 
 namespace core {
 namespace interface {
-template<typename Info>
-class IInfoboard: public IInformable<Info>, public ITimedependable, public IMoveable {
-public:
-    virtual void initInfoboard() = 0;
-    bool enabled() { return m_enabled; }
+template <typename Info>
+class IInfoboard : public IInformable<Info>,
+                   public ITimedependable,
+                   public IMoveable {
+ public:
+  virtual void initInfoboard() = 0;
+  bool enabled() { return m_enabled; }
 
-protected:
-    bool m_enabled = false;
+ protected:
+  bool m_enabled = false;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IInformable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IInformable.h
@@ -5,16 +5,17 @@
 
 namespace core {
 namespace interface {
-template <typename Info> class IInformable : public IDrawable {
-public:
+template <typename Info>
+class IInformable : public IDrawable {
+ public:
   virtual void showInfo() = 0;
   virtual void hideInfo() = 0;
   virtual void updateInfo(const Info &info) = 0;
 
-protected:
+ protected:
   Info m_info;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IMovable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/IMovable.h
@@ -6,10 +6,10 @@
 namespace core {
 namespace interface {
 class IMoveable {
-public:
+ public:
   virtual void move(const osg::Vec3 &pos) = 0;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ISeparable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ISeparable.h
@@ -4,10 +4,10 @@
 namespace core {
 namespace interface {
 class ISeparable {
-public:
+ public:
   virtual void seperate() = 0;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ISeparable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ISeparable.h
@@ -1,9 +1,9 @@
-#ifndef _CORE_INTERFACES_ISEPERABLE_H
-#define _CORE_INTERFACES_ISEPERABLE_H
+#ifndef _CORE_INTERFACES_ISEPARABLE_H
+#define _CORE_INTERFACES_ISEPARABLE_H
 
 namespace core {
 namespace interface {
-class ISeperable {
+class ISeparable {
 public:
   virtual void seperate() = 0;
 };

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ITimedependable.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/interfaces/ITimedependable.h
@@ -4,14 +4,14 @@
 namespace core {
 namespace interface {
 class ITimedependable {
-public:
+ public:
   virtual void updateTime(int timestep) = 0;
   virtual int getCurrentTimeStep() const { return m_timestep; }
 
-protected:
+ protected:
   int m_timestep = 0;
 };
-} // namespace interface
-} // namespace core
+}  // namespace interface
+}  // namespace core
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/utils/color.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/utils/color.cpp
@@ -18,4 +18,4 @@ void overrideGeodeMaterial(osg::Geode *geode, osg::Material *material) {
   geode->getOrCreateStateSet()->setAttribute(material,
                                              osg::StateAttribute::OVERRIDE);
 }
-} // namespace core::utils::color
+}  // namespace core::utils::color

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/utils/color.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/utils/color.h
@@ -17,5 +17,5 @@ auto createMaterial(const osg::Vec4 &color, osg::Material::Face faceMask);
 void overrideGeodeColor(osg::Geode *geode, const osg::Vec4 &color,
                         osg::Material::Face faceMask = osg::Material::FRONT);
 void overrideGeodeMaterial(osg::Geode *geode, osg::Material *material);
-} // namespace core::utils::color
+}  // namespace core::utils::color
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.cpp
@@ -1,4 +1,7 @@
 #include "osgUtils.h"
+
+#include <utils/color.h>
+
 #include <memory>
 #include <osg/BoundingBox>
 #include <osg/Geode>
@@ -6,47 +9,45 @@
 #include <osg/ShapeDrawable>
 #include <osg/Vec4>
 #include <osg/ref_ptr>
-#include <utils/color.h>
 
 namespace core::utils::osgUtils {
-std::unique_ptr<Geodes> getGeodes(osg::Group* grp) {
-    Geodes geodes{};
-    for (auto i = 0; i < grp->getNumChildren(); ++i) {
-        auto child = grp->getChild(i);
-        if (osg::ref_ptr<osg::Geode> child_geode = dynamic_cast<osg::Geode*>(child)) {
-            geodes.push_back(child_geode);
-            continue;
-        }
-        if (osg::ref_ptr<osg::Group> child_group = dynamic_cast<osg::Group*>(child)) {
-            auto child_geodes = getGeodes(child_group);
-            std::move(child_geodes->begin(), child_geodes->end(), std::back_inserter(geodes));
-        }
+std::unique_ptr<Geodes> getGeodes(osg::Group *grp) {
+  Geodes geodes{};
+  for (auto i = 0; i < grp->getNumChildren(); ++i) {
+    auto child = grp->getChild(i);
+    if (osg::ref_ptr<osg::Geode> child_geode = dynamic_cast<osg::Geode *>(child)) {
+      geodes.push_back(child_geode);
+      continue;
     }
-    return std::make_unique<Geodes>(geodes);
+    if (osg::ref_ptr<osg::Group> child_group = dynamic_cast<osg::Group *>(child)) {
+      auto child_geodes = getGeodes(child_group);
+      std::move(child_geodes->begin(), child_geodes->end(),
+                std::back_inserter(geodes));
+    }
+  }
+  return std::make_unique<Geodes>(geodes);
 }
 
-osg::BoundingBox getBoundingBox(const std::vector<osg::ref_ptr<osg::Geode>> &geodes) {
-    osg::BoundingBox bb;
-    for (auto geode: geodes) {
-        bb.expandBy(geode->getBoundingBox());
-    }
-    return bb;
+osg::BoundingBox getBoundingBox(
+    const std::vector<osg::ref_ptr<osg::Geode>> &geodes) {
+  osg::BoundingBox bb;
+  for (auto geode : geodes) {
+    bb.expandBy(geode->getBoundingBox());
+  }
+  return bb;
 }
 
 void deleteChildrenFromOtherGroup(osg::Group *grp, osg::Group *other) {
-  if (!grp || !other)
-    return;
+  if (!grp || !other) return;
 
   for (int i = 0; i < other->getNumChildren(); ++i) {
     auto child = other->getChild(i);
-    if (grp->containsNode(child))
-      grp->removeChild(child);
+    if (grp->containsNode(child)) grp->removeChild(child);
   }
 }
 
 void deleteChildrenRecursive(osg::Group *grp) {
-  if (!grp)
-    return;
+  if (!grp) return;
 
   for (int i = 0; i < grp->getNumChildren(); ++i) {
     auto child = grp->getChild(i);
@@ -66,8 +67,7 @@ void deleteChildrenRecursive(osg::Group *grp) {
  * @param cylinderColor The color of the cylinder.
  * @param group The group to which the cylinder will be added.
  */
-osg::ref_ptr<osg::Geode> createCylinderBetweenPoints(osg::Vec3 start,
-                                                     osg::Vec3 end,
+osg::ref_ptr<osg::Geode> createCylinderBetweenPoints(osg::Vec3 start, osg::Vec3 end,
                                                      float radius,
                                                      osg::Vec4 cylinderColor) {
   osg::ref_ptr geode = new osg::Geode;
@@ -105,4 +105,4 @@ osg::ref_ptr<osg::Geode> createCylinderBetweenPoints(osg::Vec3 start,
 
   return geode;
 }
-} // namespace core::utils::osgUtils
+}  // namespace core::utils::osgUtils

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.h
@@ -1,10 +1,17 @@
 #ifndef _CORE_UTILS_OSGUTILS_H
 #define _CORE_UTILS_OSGUTILS_H
 
+#include <memory>
+#include <osg/BoundingBox>
 #include <osg/Geode>
+#include <vector>
 
 namespace core::utils::osgUtils {
 
+typedef std::vector<osg::ref_ptr<osg::Geode>> Geodes;
+
+std::unique_ptr<Geodes> getGeodes(osg::Group* grp);
+osg::BoundingBox getBoundingBox(const Geodes &geodes);
 void deleteChildrenFromOtherGroup(osg::Group *grp, osg::Group *anotherGrp);
 void deleteChildrenRecursive(osg::Group *grp);
 /**

--- a/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/core/utils/osgUtils.h
@@ -10,7 +10,7 @@ namespace core::utils::osgUtils {
 
 typedef std::vector<osg::ref_ptr<osg::Geode>> Geodes;
 
-std::unique_ptr<Geodes> getGeodes(osg::Group* grp);
+std::unique_ptr<Geodes> getGeodes(osg::Group *grp);
 osg::BoundingBox getBoundingBox(const Geodes &geodes);
 void deleteChildrenFromOtherGroup(osg::Group *grp, osg::Group *anotherGrp);
 void deleteChildrenRecursive(osg::Group *grp);
@@ -24,9 +24,8 @@ void deleteChildrenRecursive(osg::Group *grp);
  * @param cylinderColor The color of the cylinder.
  * @param group The group to which the cylinder will be added.
  */
-osg::ref_ptr<osg::Geode> createCylinderBetweenPoints(osg::Vec3 start,
-                                                     osg::Vec3 end,
+osg::ref_ptr<osg::Geode> createCylinderBetweenPoints(osg::Vec3 start, osg::Vec3 end,
                                                      float radius,
                                                      osg::Vec4 cylinderColor);
-} // namespace core::utils::osgUtils
+}  // namespace core::utils::osgUtils
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/building.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/building.cpp
@@ -1,4 +1,5 @@
 #include "building.h"
+
 #include <sstream>
 
 namespace ennovatis {
@@ -17,9 +18,8 @@ void Channel::clear() {
 
 const std::string Channel::to_string() const {
   std::stringstream ss;
-  ss << "name: " << name << "\ndescription: " << description
-     << "\ntype: " << type << "\nunit: " << unit
-     << "\nChannelgroup: " << ChannelGroupToString(group);
+  ss << "name: " << name << "\ndescription: " << description << "\ntype: " << type
+     << "\nunit: " << unit << "\nChannelgroup: " << ChannelGroupToString(group);
   return ss.str();
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/building.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/building.h
@@ -1,10 +1,11 @@
 #ifndef _BUILDING_H
 #define _BUILDING_H
 
-#include "channel.h"
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "channel.h"
 
 namespace ennovatis {
 
@@ -16,10 +17,9 @@ namespace ennovatis {
  * channels.
  */
 class Building {
-public:
+ public:
   // typedef std::shared_ptr<Building> ptr;
-  Building(const std::string &name, const std::string &id,
-           const std::string &street)
+  Building(const std::string &name, const std::string &id, const std::string &street)
       : m_name(name), m_id(id), m_street(street), m_y(0), m_x(0), m_height(0){};
   Building(const std::string &name, const std::string &id)
       : Building(name, id, ""){};
@@ -53,8 +53,8 @@ public:
   [[nodiscard]] const auto &getX() const { return m_x; }
   [[nodiscard]] const auto &getHeight() const { return m_height; }
   [[nodiscard]] const std::string to_string() const {
-    return "Building: " + m_name + "\nID: " + m_id + "\n" +
-           "\nStreet: " + m_street + "\n";
+    return "Building: " + m_name + "\nID: " + m_id + "\n" + "\nStreet: " + m_street +
+           "\n";
   }
   void setName(const std::string &name) { m_name = name; }
   void setId(const std::string &id) { m_id = id; }
@@ -63,7 +63,7 @@ public:
   void setX(float lon) { m_x = lon; }
   void setHeight(float h) { m_height = h; }
 
-private:
+ private:
   std::string m_name;
   std::string m_street;
   std::string m_id;
@@ -75,5 +75,5 @@ private:
 
 typedef std::vector<Building> Buildings;
 typedef std::shared_ptr<Buildings> BuildingsPtr;
-} // namespace ennovatis
+}  // namespace ennovatis
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/channel.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/channel.h
@@ -6,25 +6,19 @@
 #include <string>
 
 namespace ennovatis {
-enum ChannelGroup {
-  Strom,
-  Wasser,
-  Waerme,
-  Kaelte,
-  None
-}; // keep None at the end
+enum ChannelGroup { Strom, Wasser, Waerme, Kaelte, None };  // keep None at the end
 constexpr const char *ChannelGroupToString(ChannelGroup group) {
   switch (group) {
-  case ChannelGroup::Strom:
-    return "Strom";
-  case ChannelGroup::Wasser:
-    return "Wasser";
-  case ChannelGroup::Waerme:
-    return "Waerme";
-  case ChannelGroup::Kaelte:
-    return "Kaelte";
-  case ChannelGroup::None:
-    return "None";
+    case ChannelGroup::Strom:
+      return "Strom";
+    case ChannelGroup::Wasser:
+      return "Wasser";
+    case ChannelGroup::Waerme:
+      return "Waerme";
+    case ChannelGroup::Kaelte:
+      return "Kaelte";
+    case ChannelGroup::None:
+      return "None";
   }
   return "None";
 }
@@ -56,7 +50,6 @@ struct ChannelCmp {
 };
 
 typedef std::set<Channel, ChannelCmp> ChannelList;
-typedef std::array<ChannelList, static_cast<int>(ChannelGroup::None)>
-    ChannelGroups;
-} // namespace ennovatis
+typedef std::array<ChannelList, static_cast<int>(ChannelGroup::None)> ChannelGroups;
+}  // namespace ennovatis
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/csv.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/csv.cpp
@@ -1,10 +1,12 @@
 #include "csv.h"
-#include "building.h"
-#include "utils/read/csv/csv.h"
+
 #include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <sstream>
 #include <string>
+
+#include "building.h"
+#include "utils/read/csv/csv.h"
 
 namespace {
 
@@ -19,7 +21,7 @@ void channelgroup_switch(ennovatis::Channel &channel, const std::string &val) {
   else if (algo::contains(val, "COOLING"))
     channel.group = ennovatis::ChannelGroup::Kaelte;
 }
-} // namespace
+}  // namespace
 
 namespace ennovatis {
 
@@ -37,10 +39,9 @@ bool csv_channelid_parser::update_buildings_by_buildingid(
         const auto &name_channel_dir = row["Gebaude/Kanalordner"];
         const auto name =
             name_channel_dir.substr(0, name_channel_dir.find_last_of('-'));
-        buildingIt = std::find_if(buildings->begin(), buildings->end(),
-                                  [&name](const Building &b) {
-                                    return b.getId().compare(name) >= 0;
-                                  });
+        buildingIt = std::find_if(
+            buildings->begin(), buildings->end(),
+            [&name](const Building &b) { return b.getId().compare(name) >= 0; });
         if (buildingIt == buildings->end()) {
           buildings->push_back(Building(name, building_id));
           buildingIt = buildings->end() - 1;
@@ -50,14 +51,13 @@ bool csv_channelid_parser::update_buildings_by_buildingid(
 
       // channelid in csv is not the same as the channel id on server side
       const auto &channel_id =
-          row["GlobalId"] + "_5"; // _5 needed to specify as channel
+          row["GlobalId"] + "_5";  // _5 needed to specify as channel
       const auto &channel_type = row["Medium"];
 
       Channel channel{row["Kanal"], channel_id, row["Beschreibung"],
                       channel_type, "None",     ChannelGroup::None};
       channelgroup_switch(channel, channel_type);
-      if (channel.group == ChannelGroup::None)
-        continue;
+      if (channel.group == ChannelGroup::None) continue;
 
       buildingIt->addChannel(channel, channel.group);
     }
@@ -73,18 +73,16 @@ bool csv_channelid_parser::update_buildings_by_buildingid(
     std::basic_istream<char> &file, BuildingsPtr buildings) {
   std::string row("");
   std::string lastBuildingId("");
-  std::getline(file, row); // skip header
+  std::getline(file, row);  // skip header
   std::vector<Building>::iterator buildingIt;
   while (file.good()) {
     std::getline(file, row);
-    if (row.empty())
-      continue;
+    if (row.empty()) continue;
 
     std::istringstream ss(row);
     std::string column("");
     std::vector<std::string> columns;
-    while (std::getline(ss, column, ','))
-      columns.push_back(column);
+    while (std::getline(ss, column, ',')) columns.push_back(column);
 
     const auto &building_id = columns[(int)CSV_ChannelID_Column::BUILDING_ID];
     if (building_id != lastBuildingId) {
@@ -106,7 +104,7 @@ bool csv_channelid_parser::update_buildings_by_buildingid(
     const auto &channel_name = columns[(int)CSV_ChannelID_Column::CHANNEL];
     // channelid in csv is not the same as the channel id on server side
     const auto &channel_id = columns[(int)CSV_ChannelID_Column::GLOBAL_ID] +
-                             "_5"; // _5 needed to specify as channel
+                             "_5";  // _5 needed to specify as channel
     const auto &channel_description =
         columns[(int)CSV_ChannelID_Column::DESCRIPTION];
     const auto &channel_type = columns[(int)CSV_ChannelID_Column::TYPE];
@@ -114,11 +112,10 @@ bool csv_channelid_parser::update_buildings_by_buildingid(
     Channel channel{channel_name, channel_id, channel_description,
                     channel_type, "None",     ChannelGroup::None};
     channelgroup_switch(channel, channel_type);
-    if (channel.group == ChannelGroup::None)
-      continue;
+    if (channel.group == ChannelGroup::None) continue;
 
     buildingIt->addChannel(channel, channel.group);
   }
   return true;
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/csv.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/csv.h
@@ -1,20 +1,19 @@
 #ifndef _CSV_H
 #define _CSV_H
 
-#include "building.h"
 #include <iostream>
+
+#include "building.h"
 
 namespace ennovatis {
 
 struct csv_channelid_parser {
-  [[nodiscard]] static bool
-  update_buildings_by_buildingid(std::basic_istream<char> &file,
-                                 BuildingsPtr buildings);
-  [[nodiscard]] static bool
-  update_buildings_by_buildingid(const std::string &filename,
-                                 BuildingsPtr buildings);
+  [[nodiscard]] static bool update_buildings_by_buildingid(
+      std::basic_istream<char> &file, BuildingsPtr buildings);
+  [[nodiscard]] static bool update_buildings_by_buildingid(
+      const std::string &filename, BuildingsPtr buildings);
 
-private:
+ private:
   enum class CSV_ChannelID_Column {
     PROJECT = 0,
     PROJECT_ID = 1,
@@ -35,5 +34,5 @@ private:
   };
 };
 
-} // namespace ennovatis
+}  // namespace ennovatis
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/date.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/date.cpp
@@ -1,4 +1,5 @@
 #include "date.h"
+
 #include <chrono>
 #include <iomanip>
 #include <sstream>
@@ -8,21 +9,20 @@ using namespace std;
 
 namespace ennovatis {
 
-std::chrono::system_clock::time_point
-date::str_to_time_point(const string &datetimeString, const char *format) {
+std::chrono::system_clock::time_point date::str_to_time_point(
+    const string &datetimeString, const char *format) {
   tm tmStruct = {};
   istringstream ss(datetimeString);
   ss >> get_time(&tmStruct, format);
   return chrono::system_clock::from_time_t(mktime(&tmStruct));
 }
 
-std::string
-date::time_point_to_str(const chrono::system_clock::time_point &timePoint,
-                        const char *format) {
+std::string date::time_point_to_str(
+    const chrono::system_clock::time_point &timePoint, const char *format) {
   time_t time = chrono::system_clock::to_time_t(timePoint);
   tm *timeinfo = localtime(&time);
   char buffer[70];
   strftime(buffer, sizeof(buffer), format, timeinfo);
   return buffer;
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/date.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/date.h
@@ -18,8 +18,8 @@ struct date {
    * @param format The format of the datetime string.
    * @return The converted std::chrono::system_clock::time_point object.
    */
-  [[nodiscard]] static std::chrono::system_clock::time_point
-  str_to_time_point(const std::string &datetimeString, const char *format);
+  [[nodiscard]] static std::chrono::system_clock::time_point str_to_time_point(
+      const std::string &datetimeString, const char *format);
 
   /**
    * @brief Returns a formatted string representation of the given time point.
@@ -29,9 +29,8 @@ struct date {
    * @param format The format string specifying the desired format.
    * @return The formatted string representation of the time point.
    */
-  [[nodiscard]] static std::string
-  time_point_to_str(const std::chrono::system_clock::time_point &timePoint,
-                    const char *format);
+  [[nodiscard]] static std::string time_point_to_str(
+      const std::chrono::system_clock::time_point &timePoint, const char *format);
 };
-} // namespace ennovatis
+}  // namespace ennovatis
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/json.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/json.cpp
@@ -1,4 +1,5 @@
 #include "json.h"
+
 #include <sstream>
 
 using json = nlohmann::json;
@@ -14,11 +15,9 @@ json_response_object::operator std::string() const {
       << "MinValue: " << std::to_string(MinValue) << "\n"
       << "StandardDeviation: " << std::to_string(StandardDeviation) << "\n";
   oss << "Times: " << "\n";
-  for (auto &time : Times)
-    oss << time << "\n";
+  for (auto &time : Times) oss << time << "\n";
   oss << "Values: " << "\n";
-  for (auto &value : Values)
-    oss << std::to_string(value) << "\n";
+  for (auto &value : Values) oss << std::to_string(value) << "\n";
   return oss.str();
 }
 
@@ -33,12 +32,12 @@ void from_json(const nlohmann::json &j, json_response_object &obj) {
   j.at("Values").get_to(obj.Values);
 }
 
-std::unique_ptr<json_response_object>
-json_parser::operator()(const std::string &s) const {
+std::unique_ptr<json_response_object> json_parser::operator()(
+    const std::string &s) const {
   try {
     return operator()(nlohmann::json::parse(s));
   } catch (json::parse_error &e) {
     return nullptr;
   }
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/json.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/json.h
@@ -21,8 +21,7 @@ struct json_response_object {
 void from_json(const nlohmann::json &j, json_response_object &obj);
 
 struct json_parser {
-  std::unique_ptr<json_response_object>
-  operator()(const nlohmann::json &j) const {
+  std::unique_ptr<json_response_object> operator()(const nlohmann::json &j) const {
     return std::make_unique<json_response_object>(
         j.template get<ennovatis::json_response_object>());
   }
@@ -37,5 +36,5 @@ struct json_parser {
    */
   std::unique_ptr<json_response_object> operator()(const std::string &s) const;
 };
-} // namespace ennovatis
+}  // namespace ennovatis
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/rest.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/rest.cpp
@@ -1,9 +1,11 @@
 #include "rest.h"
+
+#include <string>
+
 #include "HTTPClient/CURL/methods.h"
 #include "HTTPClient/CURL/request.h"
 #include "building.h"
 #include "date.h"
-#include <string>
 
 using namespace std;
 using namespace opencover::httpclient::curl;
@@ -32,8 +34,7 @@ std::string rest::fetch_data(const rest_request &req) {
   std::string response = "";
   GET getRequest(req());
   if (!Request().httpRequest(getRequest, response))
-    response =
-        "[ERROR] Failed to fetch data from Ennovatis. With request: " + req();
+    response = "[ERROR] Failed to fetch data from Ennovatis. With request: " + req();
   return response;
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/rest.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/rest.h
@@ -1,9 +1,10 @@
 #ifndef _ENERGY_ENNOVATIS_REST_H
 #define _ENERGY_ENNOVATIS_REST_H
 
+#include <string>
+
 #include "building.h"
 #include "utils/thread/threadworker.h"
-#include <string>
 
 namespace ennovatis {
 /**
@@ -13,12 +14,12 @@ namespace ennovatis {
  * URL, project ID, channel ID, time range, and resolution.
  */
 struct rest_request {
-  std::string url;                           // URL
-  std::string projEid;                       // project ID
-  std::string channelId;                     // channel ID
-  std::chrono::system_clock::time_point dtf; // from
-  std::chrono::system_clock::time_point dtt; // until
-  int ts = 86400;                            // 1 day resolution
+  std::string url;                            // URL
+  std::string projEid;                        // project ID
+  std::string channelId;                      // channel ID
+  std::chrono::system_clock::time_point dtf;  // from
+  std::chrono::system_clock::time_point dtt;  // until
+  int ts = 86400;                             // 1 day resolution
   int tsp = 0;
   int tst = 1;
   int etst = 1024;
@@ -64,7 +65,7 @@ struct rest_request_handler {
   auto checkStatus() { return worker.checkStatus(); }
   auto isRunning() { return worker.isRunning(); }
 
-private:
+ private:
   opencover::utils::ThreadWorker<std::string> worker;
 };
 
@@ -86,6 +87,6 @@ struct rest {
   [[nodiscard]] static std::string fetch_data(const rest_request &req);
 };
 
-} // namespace ennovatis
+}  // namespace ennovatis
 
 #endif

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/sax.cpp
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/sax.cpp
@@ -1,8 +1,9 @@
 #include <build_options.h>
 #include <building.h>
+#include <sax.h>
+
 #include <cstdlib>
 #include <nlohmann/json.hpp>
-#include <sax.h>
 
 using json = nlohmann::json;
 namespace {
@@ -34,12 +35,11 @@ void add_attr_to_channel(ennovatis::Channel &channel, const std::string &key,
   else if (key == "group")
     channelgroup_switch(channel, val);
 }
-} // namespace
+}  // namespace
 
 namespace ennovatis {
 bool sax_channelid_parser::string(string_t &val) {
-  if constexpr (debug)
-    m_debugLogs.push_back("string(val=" + val + ")");
+  if constexpr (debug) m_debugLogs.push_back("string(val=" + val + ")");
 
   if (m_isBuilding) {
     m_buildings->push_back(Building(val.c_str()));
@@ -54,8 +54,7 @@ bool sax_channelid_parser::string(string_t &val) {
 }
 
 bool sax_channelid_parser::key(string_t &val) {
-  if constexpr (debug)
-    m_debugLogs.push_back("key(val=" + val + ")");
+  if constexpr (debug) m_debugLogs.push_back("key(val=" + val + ")");
 
   if (m_isObj) {
     m_isBuilding = val == "building";
@@ -68,8 +67,7 @@ bool sax_channelid_parser::key(string_t &val) {
 }
 
 bool sax_channelid_parser::null() {
-  if constexpr (debug)
-    m_debugLogs.push_back("null()");
+  if constexpr (debug) m_debugLogs.push_back("null()");
   return true;
 }
 
@@ -94,25 +92,22 @@ bool sax_channelid_parser::number_unsigned(number_unsigned_t val) {
 
 bool sax_channelid_parser::number_float(number_float_t val, const string_t &s) {
   if constexpr (debug)
-    m_debugLogs.push_back("number_float(val=" + std::to_string(val) +
-                          ", s=" + s + ")");
+    m_debugLogs.push_back("number_float(val=" + std::to_string(val) + ", s=" + s +
+                          ")");
   return true;
 }
 
 bool sax_channelid_parser::start_object(std::size_t elements) {
   if constexpr (debug)
-    m_debugLogs.push_back("start_object(elements=" + std::to_string(elements) +
-                          ")");
+    m_debugLogs.push_back("start_object(elements=" + std::to_string(elements) + ")");
   m_isObj = true;
   return true;
 }
 
 bool sax_channelid_parser::end_object() {
-  if constexpr (debug)
-    m_debugLogs.push_back("end_object()");
+  if constexpr (debug) m_debugLogs.push_back("end_object()");
 
-  if (m_isChannel)
-    m_buildings->back().addChannel(m_channel, m_channel.group);
+  if (m_isChannel) m_buildings->back().addChannel(m_channel, m_channel.group);
 
   m_isChannel = false;
   return true;
@@ -120,20 +115,17 @@ bool sax_channelid_parser::end_object() {
 
 bool sax_channelid_parser::start_array(std::size_t elements) {
   if constexpr (debug)
-    m_debugLogs.push_back("start_array(elements=" + std::to_string(elements) +
-                          ")");
+    m_debugLogs.push_back("start_array(elements=" + std::to_string(elements) + ")");
   return true;
 }
 
 bool sax_channelid_parser::end_array() {
-  if constexpr (debug)
-    m_debugLogs.push_back("end_array()");
+  if constexpr (debug) m_debugLogs.push_back("end_array()");
   return true;
 }
 
 bool sax_channelid_parser::binary(json::binary_t &val) {
-  if constexpr (debug)
-    m_debugLogs.push_back("binary(val=[...])");
+  if constexpr (debug) m_debugLogs.push_back("binary(val=[...])");
   return true;
 }
 
@@ -146,4 +138,4 @@ bool sax_channelid_parser::parse_error(std::size_t position,
                           ",\n            ex=" + std::string(ex.what()) + ")");
   return false;
 }
-} // namespace ennovatis
+}  // namespace ennovatis

--- a/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/sax.h
+++ b/src/OpenCOVER/plugins/hlrs/Energy/ennovatis/sax.h
@@ -1,12 +1,13 @@
 #ifndef _SAX_H
 #define _SAX_H
 
-#include "building.h"
 #include <nlohmann/json.hpp>
+
+#include "building.h"
 
 namespace ennovatis {
 struct sax_channelid_parser : public nlohmann::json::json_sax_t {
-public:
+ public:
   sax_channelid_parser() = default;
   sax_channelid_parser(BuildingsPtr buildings) : m_buildings(buildings){};
 
@@ -29,7 +30,7 @@ public:
   }
   const std::vector<std::string> &getDebugLogs() const { return m_debugLogs; }
 
-private:
+ private:
   bool m_isBuilding = false;
   bool m_isChannel = false;
   bool m_isBuildingID = false;
@@ -41,6 +42,6 @@ private:
   std::vector<std::string> m_debugLogs;
   BuildingsPtr m_buildings;
 };
-} // namespace ennovatis
+}  // namespace ennovatis
 
 #endif


### PR DESCRIPTION
At the moment ViewAll uses all nodes attached in the scene graph. Even those that are not visible. Using the osg function computeBound() fixes this issue.