### PR TITLE
add button ViewVisible to COVER

### DIFF
--- a/src/OpenCOVER/cover/VRSceneGraph.cpp
+++ b/src/OpenCOVER/cover/VRSceneGraph.cpp
@@ -1521,9 +1521,9 @@ VRSceneGraph::getBoundingSphere()
     return bsphere;
 }
 
-void VRSceneGraph::scaleAllObjects(bool resetView)
+void VRSceneGraph::scaleAllObjects(bool resetView, bool simple)
 {
-    osg::BoundingSphere bsphere = getBoundingSphere();
+    osg::BoundingSphere bsphere = simple ? m_objectsRoot->computeBound() : getBoundingSphere();
     if (bsphere.radius() <= 0.f)
         bsphere.radius() = 1.f;
 
@@ -1652,11 +1652,11 @@ VRSceneGraph::manipulateCallback(void *sceneGraph, buttonSpecCell *spec)
 #endif
 
 void
-VRSceneGraph::viewAll(bool resetView)
+VRSceneGraph::viewAll(bool resetView, bool simple)
 {
     coVRNavigationManager::instance()->enableViewerPosRotation(false);
 
-    scaleAllObjects(resetView);
+    scaleAllObjects(resetView, simple);
 
     coVRCollaboration::instance()->SyncXform();
 }

--- a/src/OpenCOVER/cover/VRSceneGraph.h
+++ b/src/OpenCOVER/cover/VRSceneGraph.h
@@ -141,7 +141,7 @@ public:
     osg::StateSet *loadGlobalGeostate();
     osg::StateSet *loadUnlightedGeostate(osg::Material::ColorMode mode = osg::Material::OFF);
     osg::StateSet *loadTransparentGeostate(osg::Material::ColorMode mode = osg::Material::OFF);
-    osg::StateSet *loadDefaultPointstate(float pointSize = 4, osg::Material::ColorMode mode = osg::Material::OFF); 
+    osg::StateSet *loadDefaultPointstate(float pointSize = 4, osg::Material::ColorMode mode = osg::Material::OFF);
     void setWireframe(WireframeMode mode);
     void setPointerType(int pointerType);
     int getPointerType()
@@ -206,7 +206,7 @@ public:
         return m_scaleFactor;
     }
     void setScaleFactor(float scaleFactor, bool sync = true);
-    void scaleAllObjects(bool resetView = false);
+    void scaleAllObjects(bool resetView = false, bool simple = false);
     bool isScalingAllObjects() const
     {
         return m_scalingAllObjects;
@@ -217,7 +217,7 @@ public:
 
     void toggleAxis(bool state);
     void toggleHighQuality(bool state);
-    void viewAll(bool resetView = false);
+    void viewAll(bool resetView = false, bool simple = false);
     float floorHeight()
     {
         return m_floorHeight;

--- a/src/OpenCOVER/cover/coVRNavigationManager.cpp
+++ b/src/OpenCOVER/cover/coVRNavigationManager.cpp
@@ -411,7 +411,16 @@ void coVRNavigationManager::initMenu()
     m_viewAll->setPriority(ui::Element::Toolbar);
     m_viewAll->setIcon("zoom-fit-best");
 
-
+    m_viewVisible = new ui::Action(navMenu_, "ViewVisible");
+    m_viewVisible->setText("View visible");
+    m_viewVisible->setShortcut("Shift+Alt+V");
+    m_viewVisible->setCallback([this, protectNav](){
+        protectNav([](){
+            VRSceneGraph::instance()->viewAll(false, true);
+        });
+    });
+    m_viewVisible->setPriority(ui::Element::Toolbar);
+    m_viewVisible->setIcon("zoom-to-visible");
 
 
     centerViewButton = new ui::Action(navMenu_, "centerView");
@@ -1190,7 +1199,7 @@ coVRNavigationManager::update()
 			break;
 		}
 	}
-    
+
 
     // was ist wenn mehrere Objekte geladen sind???
 
@@ -2743,7 +2752,7 @@ void coVRNavigationManager::doWalkMoveToFloor()
 
     // do not sync with remote, they will do the same
     // on their side SyncXform();
-	
+
     // coVRCollaboration::instance()->SyncXform();
 }
 

--- a/src/OpenCOVER/cover/coVRNavigationManager.h
+++ b/src/OpenCOVER/cover/coVRNavigationManager.h
@@ -351,7 +351,7 @@ private:
     vrui::coRowMenu *nameMenu_;
     vrui::coButtonMenuItem *nameButton_;
     ui::Menu *navMenu_ = nullptr;
-    ui::Action *m_viewAll=nullptr, *m_resetView=nullptr;
+    ui::Action *m_viewAll=nullptr, *m_resetView=nullptr, *m_viewVisible=nullptr;
     ui::Group *navModes_ = nullptr;
     ui::ButtonGroup *navGroup_ = nullptr;
     ui::Button *noNavButton_=nullptr;
@@ -378,7 +378,7 @@ private:
     void initMenu();
     void initShowName();
     void initMeasure();
-    
+
     osg::Vec3 getCenter() const;
     void centerView();
     osg::Vec3 mouseNavCenter;


### PR DESCRIPTION
The new button scales the view like "ViewAll", but uses internally an easier and faster implementation to compute the boundingsphere. Only visible objects in the scene graph are traversed instead of all.