### PR TITLE
Fix syncToVBlank for Qt > 6.2 GraphicsWindow

### DIFF
--- a/src/OpenCOVER/plugins/general/WindowTypeQt/QtOsgWidgetImpl.cpp
+++ b/src/OpenCOVER/plugins/general/WindowTypeQt/QtOsgWidgetImpl.cpp
@@ -38,9 +38,10 @@ void QtGraphicsWindow::setSyncToVBlank(bool flag)
     }
     else
 #endif
-    if (glewInit() != GLEW_OK)
+    GLenum err = glewInit();
+    if (err != GLEW_OK)
     {
-        std::cerr << "setSyncToVBlank: failed to initialize GLEW" << std::endl;
+        std::cerr << "setSyncToVBlank: failed to initialize GLEW. Error: " << glewGetErrorString(err) << std::endl;
     }
 
     auto wid = m_glWidget->effectiveWinId();
@@ -66,7 +67,6 @@ void QtGraphicsWindow::setSyncToVBlank(bool flag)
     }
 
     int screenNumber = XScreenNumberOfScreen(XDefaultScreenOfDisplay(dpy));
-
     //  const char *s = glXQueryExtensionsString(dpy, wid);
      const char *s = glXQueryExtensionsString(dpy, screenNumber);
      if(s==nullptr)
@@ -82,5 +82,6 @@ void QtGraphicsWindow::setSyncToVBlank(bool flag)
     }
 
     glXSwapIntervalEXT(dpy, wid, flag ? 1 : 0);
+    std::cout << "setSyncToVBlank: " << (flag ? "enabled" : "disabled") << " for XScreen " << screenNumber << std::endl;
 #endif
 }

--- a/src/OpenCOVER/plugins/general/WindowTypeQt/QtOsgWidgetImpl.cpp
+++ b/src/OpenCOVER/plugins/general/WindowTypeQt/QtOsgWidgetImpl.cpp
@@ -4,6 +4,9 @@
 #ifdef HAVE_QTX11EXTRAS
 #include <QX11Info>
 #endif
+#if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+#include <QGuiApplication>
+#endif
 
 #include <GL/glxew.h>
 #undef Status
@@ -47,24 +50,31 @@ void QtGraphicsWindow::setSyncToVBlank(bool flag)
         return;
     }
 
-#ifdef HAVE_QTX11EXTRAS
-    Display *dpy = QX11Info::display();
-#else
     Display *dpy = nullptr;
-#endif
+
+    #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)
+        dpy = qGuiApp->nativeInterface<QNativeInterface::QX11Application>()->display();
+    #else
+        #ifdef HAVE_QTX11EXTRAS
+            dpy = QX11Info::display();
+        #endif
+    #endif
     if (!dpy)
     {
         std::cerr << "setSyncToVBlank: did not find Display for application" << std::endl;
         return;
     }
-    
-     const char *s = glXQueryExtensionsString(dpy, wid);
+
+    int screenNumber = XScreenNumberOfScreen(XDefaultScreenOfDisplay(dpy));
+
+    //  const char *s = glXQueryExtensionsString(dpy, wid);
+     const char *s = glXQueryExtensionsString(dpy, screenNumber);
      if(s==nullptr)
      {
          std::cerr << "no extensions, probably running MESA" << std::endl;
          return;
      }
-   
+
      if (!glXSwapIntervalEXT)
     {
         std::cerr << "setSyncToVBlank: no glXSwapIntervalEXT" << std::endl;


### PR DESCRIPTION
SyncToVBlank didn't work with Qt6 version of COVER, because of removed QTX11Info util in newer versions of Qt. The fix uses the Qt6 API function display() (available since Qt 6.2) to get the right display pointer to be able to enable/disable syncToVBlank for current window. 

More infos about display():

- https://doc.qt.io/qt-6/qnativeinterface-qx11application.html
- https://code.qt.io/cgit/qt/qtbase.git/commit/?id=f5203eeada83bbe8e316a5188e24636af3e83b09