### PR TITLE
Rework Deb Building to support multiple versions

### DIFF
--- a/.github/workflows/release_deb.yml
+++ b/.github/workflows/release_deb.yml
@@ -10,15 +10,30 @@ permissions:
 
 jobs:
   build:
-    name: Ubuntu Package Build
-    # ubuntu:latest = current LTS version
+    strategy:
+      fail-fast: false
+      matrix:
+        distro_version: [latest, plucky]
+        include:
+          - distro_version: latest
+            container_image: ubuntu:latest
+            display_name: Ubuntu LTS (latest)
+          - distro_version: plucky
+            container_image: ubuntu:25.04
+            display_name: Ubuntu 25.04
+
+    name: ${{ matrix.display_name }} Package Build
     runs-on: ubuntu-latest
+
+    container: ${{ matrix.container_image }}
+
     steps:
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'
         run: >
-          sudo apt-get update && sudo apt-get install
+          apt-get update && apt-get install -y
           build-essential
+          git
           cmake
           ninja-build
           debhelper
@@ -86,29 +101,19 @@ jobs:
           qt6-websockets-dev
           qt6-webview-dev
 
-      - name: Free disk space
-        if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@main
-        with:
-          # this might remove tools that are actually needed, but frees about 6 GB
-          tool-cache: false
-          # all of these default to true, but feel free to set to "false" if necessary for your workflow
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
-      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
 
+      - name: Add safe directory
+        run: |
+          git config --global --add safe.directory /__w/covise/covise
+
       - name: Sync and update submodules recursive
-        uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
+        run: |
+          git submodule sync --recursive
+          git submodule update --init --recursive
 
       - name: Copy debian dir to root src dir
         run: |
@@ -127,12 +132,11 @@ jobs:
           export DEBFULLNAME="${{ github.actor }}"
           export DEBEMAIL="${{ github.actor }}@users.noreply.github.com"
           
-          # The distribution is set to noble since ubuntu-latest is 24.04 (Noble Numbat)
-          dch --newversion "${VERSION}-1" --distribution noble "${RELEASE_BODY}"
+          dch --newversion "${VERSION}" --distribution "$(lsb_release -c -s)" "${RELEASE_BODY}"
 
       - name: Build deb
         run: |
-          source $GITHUB_WORKSPACE/.covise.sh && dpkg-buildpackage -uc -us -j$(nproc) 
+          . $GITHUB_WORKSPACE/.covise.sh && dpkg-buildpackage -uc -us -j$(nproc) 
 
       - name: Rename Deb
         run: |


### PR DESCRIPTION
- use startegy matrix to specify ubuntu version
- building version latest (LTS latest) and plucky (25.04)
- remove step to free disk

Sucessfull Run: https://github.com/MDjur/covise/releases 