### PR TITLE
Cgns cpex 41 fix

### DIFF
--- a/src/module/spbgpu/ReadCGNS/ReadCGNS.cpp
+++ b/src/module/spbgpu/ReadCGNS/ReadCGNS.cpp
@@ -38,13 +38,6 @@
 #include <string>
 #include <sstream>
 
-string int2str(int n)
-{
-    std::ostringstream o;
-    o << n;
-    return o.str();
-}
-
 void err_callback(int error, char *errmsg) {
     cout<<"CGNS Error: code= "<<error<<", msg= "<<errmsg<<endl;
 
@@ -110,7 +103,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
 
     //TODO:Optimize param()
 
-    string fileParam = "SGNS_File"; //,float1param="float_1";
+    const string fileParam = "SGNS_File"; //,float1param="float_1";
     //sendInfo("ReadCGNS::param()=====Parameter changed:%s , %d",paramName,(int)inMapLoading);
 
     //if (true/*(fileParam==paramName)*//*&&(!inMapLoading)*/) //need to check every param
@@ -120,7 +113,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
     if (param_use_file_timesteps->getValue())
     {
         char fname[300];
-        indexed_file_name(fname, param_first_file_idx->getValue());
+        indexed_file_name(fname, static_cast<int>(param_first_file_idx->getValue()));
         sendWarning("ReadCGNS::param(): Multifile. Using name '%s'", fname);
         error = cg_open(fname, CG_MODE_READ, &index_file);
     }
@@ -142,7 +135,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
         int numzones = 0;
 
         //for the first zone
-        cgsize_t zonesize[3]; //3 sizes for unstructured grid
+        cgsize_t zonesize[9]; //3 sizes for unstructured grid; max 9 sizes for 3d structured grid
         char zonename[100];
         CGNS_ENUMT(ZoneType_t) zonetype;
 
@@ -151,7 +144,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
         //1. How many bases do we have
         cg_nbases(index_file, &numbases);
 
-        // I should cycle the bases , but now i'll use the first one.
+        // I should cycle the bases , but now I'll use the first one.
         // However, multiple bases=multiple cases, so numbases >1 is very rare.
 
         // 2. read base info
@@ -162,8 +155,8 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
         error = cg_nzones(index_file, ibase, &numzones);
         if (error)
             sendInfo("param: nzones error=%d", error);
-        error = cg_zone_read(index_file, ibase, izone, zonename, zonesize);
-        error = cg_zone_type(index_file, ibase, izone, &zonetype);
+        cg_zone_read(index_file, ibase, izone, zonename, zonesize);
+        cg_zone_type(index_file, ibase, izone, &zonetype);
         //	sendInfo("param: Zones:%d.     Zone#1: name=%s , type=%d",numzones,zonename,zonetype);
         //	sendInfo("param: Sizes for unstructured grid: Verts=%d Elements=%d BoundVerts=%d",zonesize[0],zonesize[1],zonesize[2]);
 
@@ -171,18 +164,18 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
 
         int nsols = 0;
         int isol = 1;
-        error = cg_nsols(index_file, ibase, izone, &nsols); //check the number of existing solutions
+        cg_nsols(index_file, ibase, izone, &nsols); //check the number of existing solutions
         //sendInfo("param: Solutions: %d",nsols);
 
         int nfields = 0;
-        error = cg_nfields(index_file, ibase, izone, isol, &nfields); //check the number of existing fields
+        cg_nfields(index_file, ibase, izone, isol, &nfields); //check the number of existing fields
         //			sendInfo("param: Number of fields: %d",nfields);
 
         char fieldname[100];
         CGNS_ENUMT(DataType_t) fieldtype;
 
         vector<string> stparams;
-        stparams.push_back("None");
+        stparams.emplace_back("None");
 
         for (int i = 1; i <= nfields; ++i)
         {
@@ -192,27 +185,25 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
                 sendError("param: Cannot read solution %d field info", i);
                 return;
             }
-            stparams.push_back(fieldname);
+            stparams.emplace_back(fieldname);
         }
         //			sendWarning("param: xv=%d ; yv=%d",param_vx->getValue(),param_vy->getValue());
-
-        int parm = -1;
 
 
 
         //sendWarning ("Setting params %s",stparams[0].c_str());
-        parm = param_vx->getValue();
+        int parm = param_vx->getValue();
         if (parm == -1)
             parm = 0;
-        param_vx->setValue((int)stparams.size(), stparams, parm);
+        param_vx->setValue(static_cast<int>(stparams.size()), stparams, parm);
         parm = param_vy->getValue();
         if (parm == -1)
             parm = 0;
-        param_vy->setValue((int)stparams.size(), stparams, parm);
+        param_vy->setValue(static_cast<int>(stparams.size()), stparams, parm);
         parm = param_vz->getValue();
         if (parm == -1)
             parm = 0;
-        param_vz->setValue((int)stparams.size(), stparams, parm);
+        param_vz->setValue(static_cast<int>(stparams.size()), stparams, parm);
 
         for (int i = 0; i < 4; ++i)
         {
@@ -220,7 +211,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
 
             if (parm == -1)
                 parm = 0;
-            param_f[i]->setValue((int)stparams.size(), stparams, parm);
+            param_f[i]->setValue(static_cast<int>(stparams.size()), stparams, parm);
 
             //TODO: Not important. change port description when variable changes.
             //Maybe this has to be done at initialisation, it doesn't work here
@@ -229,7 +220,7 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
             //sendWarning("setting port info");
         }
 
-        error = cg_close(index_file);
+        cg_close(index_file);
         //		sendInfo("ReadCGNS::param(): cg_close: error=%d ",error);
     } // cgns file open
     else
@@ -264,11 +255,18 @@ int ReadCGNS::read_params(params &p)
     return 0;
 }
 
-bool ReadCGNS::indexed_file_name(char *s, int n)
-{
-    if (sprintf(s, param_file->getValue(), n) < 0)
-        return false;
-    return true;
+
+/**
+ * Writes an indexed file name to s.
+ * For example, if file param is "file%03d.cgns" and n=4,
+ * s will be "file004.cgns".
+ *
+ * @param s Output char array of sufficient size
+ * @param n Index number
+ * @return True if it writes something
+ */
+bool ReadCGNS::indexed_file_name(char *s, const int n) const {
+    return (sprintf(s, param_file->getValue(), n) > 0);
 }
 
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -298,8 +296,8 @@ int ReadCGNS::compute(const char *port)
     {
         sendInfo("CGNS reader started, reading multiple files");
 
-        idxlo = param_first_file_idx->getValue();
-        idxhi = param_last_file_idx->getValue();
+        idxlo = static_cast<int>(param_first_file_idx->getValue());
+        idxhi = static_cast<int>(param_last_file_idx->getValue());
         numtimesteps = idxhi - idxlo + 1;
         if ((idxlo < 1) || (idxhi < 1) || (numtimesteps < 1))
         {
@@ -372,7 +370,7 @@ int ReadCGNS::compute(const char *port)
             return FAIL;
         }
         //Creating COVISE objects and ports from arrays
-        out_objs bo;
+        out_objs bo{};
         create_base_objs(b, bo, -1);
         set_output_objs(bo);
     }
@@ -426,7 +424,7 @@ int ReadCGNS::compute(const char *port)
                 //for file-based animation ibase=1
 
                 //Creating COVISE objects and ports from arrays
-                out_objs bo;
+                out_objs bo{};
                 create_base_objs(b, bo, timestep);
 
                 gridobj[timestep] = bo.gridobj;
@@ -436,31 +434,29 @@ int ReadCGNS::compute(const char *port)
             } //-----deleting base-----------
         } //for
         //terminating arrays
-        gridobj[numtimesteps] = NULL;
+        gridobj[numtimesteps] = nullptr;
         for (int i = 0; i < 4; ++i)
-            floatobj[i][numtimesteps] = NULL;
-        velobj[numtimesteps] = NULL;
+            floatobj[i][numtimesteps] = nullptr;
+        velobj[numtimesteps] = nullptr;
 
         sendWarning("Creating TIMESTEPS coDoSet");
 
-        out_objs mod_out;
+        out_objs mod_out{};
         const char *name;
 
-        string attrval = string("0 ") + int2str(numtimesteps - 1);
+        string attrval = string("0 ") + std::to_string(numtimesteps - 1);
 
         name = out_mesh->getObjName();
 
-        mod_out.gridobj = NULL;
-        if (gridobj[0] != NULL)
+        if (gridobj[0] != nullptr)
         {
             mod_out.gridobj = new coDoSet(name, &gridobj[0]);
             mod_out.gridobj->addAttribute("TIMESTEP", attrval.c_str());
-            if (mod_out.gridobj == NULL)
-                sendError("Cannot create coDoSet!");
+            // if (mod_out.gridobj == nullptr)
+            //     sendError("Cannot create coDoSet!");
         }
 
-        mod_out.velobj = NULL;
-        if (velobj[0] != NULL)
+        if (velobj[0] != nullptr)
         {
             name = out_velocity->getObjName();
             mod_out.velobj = new coDoSet(name, &velobj[0]);
@@ -469,8 +465,7 @@ int ReadCGNS::compute(const char *port)
 
         for (int i = 0; i < 4; ++i)
         {
-            mod_out.floatobj[i] = NULL;
-            if (floatobj[i][0] != NULL)
+            if (floatobj[i][0] != nullptr)
             {
                 name = out_float[i]->getObjName();
                 mod_out.floatobj[i] = new coDoSet(name, &floatobj[i][0]);
@@ -494,27 +489,24 @@ int ReadCGNS::compute(const char *port)
  * Creates distributed objects of a base
  * base 	&b 		-- source base
  * out_objs &objs	-- structure with resulting objects
- * int 		nubmer	-- number to add to name (for output
+ * int 		number	-- number to add to name (for output
  *         TIMESTEP coDoSet, (-1) == don't add anything)
  *---------------------------------------------------------*/
-int ReadCGNS::create_base_objs(base &b, out_objs &objs, int number)
+int ReadCGNS::create_base_objs(base &b, out_objs &objs, const int number)
 {
     //creating COVISE objects with correct names
     /////////////////////////
     //creating float object
     for (int i = 0; i < 4; ++i)
     {
-        objs.floatobj[i] = NULL;
-        const char *floatobjname;
+        objs.floatobj[i] = nullptr;
 
         string str;
         str.append(out_float[i]->getObjName());
         if (number != -1)
-            str.append(string("_") + int2str(number));
+            str.append(string("_") + std::to_string(number));
 
-        floatobjname = str.c_str();
-
-        if (floatobjname)
+        if (const char *floatobjname = str.c_str())
         {
             sendInfo("ReadCGNS::create_base_objs(): float objname=%s", floatobjname);
             if (b.is_single_zone())
@@ -528,16 +520,14 @@ int ReadCGNS::create_base_objs(base &b, out_objs &objs, int number)
 
     //creating COVISE vector object for velocity
 
-    objs.velobj = NULL;
-    const char *velobjname;
+    objs.velobj = nullptr;
 
     string str;
     str.append(out_velocity->getObjName());
     if (number != -1)
-        str.append(string("_") + int2str(number));
+        str.append(string("_") + std::to_string(number));
 
-    velobjname = str.c_str();
-    if (velobjname)
+    if (const char *velobjname = str.c_str())
     {
         sendInfo("ReadCGNS::create_base_objs(): vel objname=%s", velobjname);
         if (b.is_single_zone())
@@ -549,16 +539,14 @@ int ReadCGNS::create_base_objs(base &b, out_objs &objs, int number)
     //Preparing COVISE object for grid
 
     //-----creating unstructured grid object and set it for output---
-    objs.gridobj = NULL;
-    const char *usgobjname;
+    objs.gridobj = nullptr;
 
     str.clear();
     str.append(out_mesh->getObjName());
     if (number != -1)
-        str.append(string("_") + int2str(number));
+        str.append(string("_") + std::to_string(number));
 
-    usgobjname = str.c_str();
-    if (usgobjname)
+    if (const char *usgobjname = str.c_str())
     {
         sendInfo("ReadCGNS::create_base_objs(): usg objname=%s", usgobjname);
         if (b.is_single_zone())
@@ -608,12 +596,9 @@ void ReadCGNS::params_out()
  * i_base -- base no
  * _p -- parameters structure
  *-------------------------------------*/
-base::base(int i_file, int i_base, params _p)
+base::base(const int i_file, const int i_base, params _p):
+index_file(i_file),ibase(i_base),cell_dim(0),phys_dim(0),basename{},p(_p)
 {
-    p = _p;
-    index_file = i_file;
-    ibase = i_base;
-
     // read(); good only without error handling
 }
 
@@ -623,7 +608,7 @@ base::base(int i_file, int i_base, params _p)
  *---------------------------------------------------*/
 int base::read()
 {
-    if (zones.size() != 0) // if the base has been already read (that must not happen!)
+    if (!zones.empty()) // if the base has been already read (that must not happen!)
     {
         zones.clear();
         CoviseBase::sendWarning("base::read(): WARNING! Reading the base that's already read, clearing zones.");
@@ -653,7 +638,7 @@ int base::read()
     //============read zones(temp!!!)
     for (int i = 0; i < numzones; ++i)
     {
-        zones.push_back(zone(index_file, ibase, i + 1, p));
+        zones.emplace_back(index_file, ibase, i + 1, p);
         if (zones[i].read() == FAIL)
         {
             CoviseBase::sendError("base::read(): ERROR! Cannot read zone no %d", i);
@@ -684,19 +669,19 @@ coDoSet *base::create_do_set(const char *name, int type, int scal_no)
     for (int i = 0; i < zones.size(); ++i)
 
     {
-        s = string(name) + "_doset_" + int2str(i);
+        s = string(name) + "_doset_" + std::to_string(i);
         cout << s << endl;
         d_obj[i] = zones[i].create_do(s.c_str(), type, scal_no);
     }
-    d_obj[zones.size()] = NULL;
+    d_obj[zones.size()] = nullptr;
 
-    if (d_obj[0] == NULL)
+    if (d_obj[0] == nullptr)
     {
         cout << cout_red << "base::create_do_set(): ERROR! First DO ptr is NULL." << cout_norm << endl;
-        return NULL;
+        return nullptr;
     }
 
-    coDoSet *do_set = new coDoSet(name, &d_obj[0]);
+    auto *do_set = new coDoSet(name, &d_obj[0]);
 
     return do_set;
 }
@@ -716,8 +701,7 @@ coDistributedObject *base::create_do(const char *name, int type, int scal_no)
  *  bool base::single_zone()
  * returns true if the base has only one zone
  *--------------------------------------------*/
-bool base::is_single_zone()
-{
+bool base::is_single_zone() const {
     return zones.size() == 1;
 }
 

--- a/src/module/spbgpu/ReadCGNS/ReadCGNS.cpp
+++ b/src/module/spbgpu/ReadCGNS/ReadCGNS.cpp
@@ -44,6 +44,12 @@ string int2str(int n)
     o << n;
     return o.str();
 }
+
+void err_callback(int error, char *errmsg) {
+    cout<<"CGNS Error: code= "<<error<<", msg= "<<errmsg<<endl;
+
+}
+
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // ++++
@@ -96,6 +102,7 @@ ReadCGNS::ReadCGNS(int argc, char *argv[])
     out_float[3] = addOutputPort("Steam_Quality", "Float", "Steam Quality");
 
     out_velocity = addOutputPort("Velocity", "Vec3", "Velocity");
+    cg_configure(CG_CONFIG_ERROR,(void*)err_callback);
 }
 
 void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
@@ -190,6 +197,8 @@ void ReadCGNS::param(const char *paramName, bool /*inMapLoading*/)
         //			sendWarning("param: xv=%d ; yv=%d",param_vx->getValue(),param_vy->getValue());
 
         int parm = -1;
+
+
 
         //sendWarning ("Setting params %s",stparams[0].c_str());
         parm = param_vx->getValue();

--- a/src/module/spbgpu/ReadCGNS/ReadCGNS.h
+++ b/src/module/spbgpu/ReadCGNS/ReadCGNS.h
@@ -40,7 +40,7 @@ class base
 
     params p; //UI params
 
-    int error;
+    int error{0};
     enum
     {
         FAIL = -1,
@@ -53,7 +53,7 @@ public:
     base(int i_file, int i_base, params p);
     int read();
 
-    bool is_single_zone();
+    [[nodiscard]] bool is_single_zone() const;
 
     coDistributedObject *create_do(const char *name, int type, int scal_no = 0);
     coDoSet *create_do_set(const char *name, int type, int scal_no = 0);
@@ -66,7 +66,7 @@ private:
     //////////  member functions
 
     /// this module has only the compute call-back
-    virtual int compute(const char *port);
+    int compute(const char *port) override;
 
     coFileBrowserParam *param_file;
 
@@ -99,7 +99,7 @@ private:
     coOutputPort *out_velocity;
 
     void params_out();
-    bool indexed_file_name(char *s, int n);
+    bool indexed_file_name(char *s, int n) const;
 
     // ReadCGNS functions
     int read_params(params &p);
@@ -110,8 +110,8 @@ private:
     int set_output_objs(out_objs &objs);
 
     //coModule functions
-    virtual void param(const char *paramName, bool inMapLoading);
-    virtual void postInst();
+    void param(const char *paramName, bool inMapLoading) override;
+    void postInst() override;
 
 public:
     ReadCGNS(int argc, char *argv[]);

--- a/src/module/spbgpu/ReadCGNS/common.h
+++ b/src/module/spbgpu/ReadCGNS/common.h
@@ -17,6 +17,8 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
+#include <string>
+
 //"\e[31;4m"
 const char cout_red[] = "\x1b[31m"; // errors and important warnings
 const char cout_green[] = "\x1b[32m";
@@ -37,13 +39,12 @@ struct params
 {
     bool b_load_2d;
     bool b_use_string;
-    string sections_string;
+    std::string sections_string;
 
     int param_vx, param_vy, param_vz;
 
     int param_f[4];
 };
 
-string int2str(int n);
 
 #endif /* COMMON_H_ */

--- a/src/module/spbgpu/ReadCGNS/zone.cpp
+++ b/src/module/spbgpu/ReadCGNS/zone.cpp
@@ -30,7 +30,7 @@ typedef int cgsize_t;
  *  Constructor
  *-----------------------------*/
 
-zone::zone(int i_file, int i_base, int i_zone, params _p) : error(0), zonesize{0,0,0}, zonename{""}, zonetype(ZoneType_t::ZoneTypeNull) {
+zone::zone(int i_file, int i_base, int i_zone, params _p) : zonesize{0,0,0}, zonename{""}, zonetype(ZoneType_t::ZoneTypeNull) {
     index_file = i_file;
     ibase = i_base;
     izone = i_zone;
@@ -50,6 +50,11 @@ int zone::read()
 
     CoviseBase::sendInfo(" zone::read() started: name=%s , type=%d, num=%d", zonename, zonetype, izone);
 
+    if (zonetype==ZoneType_t::Structured) {
+        cout<<cout_red<<"Error: Zone `" << zonename << "' is structured. Structured grids aren't supported yet."<<cout_norm<<endl;
+        return FAIL;
+    }
+
     cout << cout_cyan << cout_underln << "==============zone::read() started======================" << endl
          << "zone::read() name=" << zonename << ", type=" << zonetype << ", no=" << izone << cout_norm << endl;
 
@@ -57,12 +62,7 @@ int zone::read()
 
     //4,5  Reading coords
 
-    fx.insert(fx.begin(), zonesize[0], 0);
-    fy.insert(fy.begin(), zonesize[0], 0);
-    fz.insert(fz.begin(), zonesize[0], 0);
-
-    //cout << "LALALALALAL!!!!!!!!!!!!!!!!!!!!!!!"<<endl<<fx.size()<<"="<<zonesize[0]<<endl;
-    if ((error = read_coords(fx, fy, fz)))
+    if (read_coords()==FAIL)
         return FAIL;
 
     //6. Reading Grid data (Sections)
@@ -81,11 +81,9 @@ int zone::read()
     }
 
     int sectionsread = 0; //How many sections we have read?
-    for (int ind = 0; ind < sections.size(); ++ind) // for_each ?
-    {
-        int isection = sections[ind];
+    for (const int isection : sections) {
         sectionsread++;
-        if ((error = read_one_section(isection, conn, elem, tl)))
+        if (read_one_section(isection)==FAIL)
             return FAIL;
     }
     cout << "zone::read():" << sectionsread << " sections read.";
@@ -97,9 +95,9 @@ int zone::read()
     }
 
     // connectivity indices should be decremented after loading
-    for (int i = 0; i < conn.size(); ++i)
-        conn[i]--; //decrementing for C++ Covise indexes from zero
-    cout << "zone::read(): Connectivities after decrement: conn[0]=" << conn[0] << ", conn[9]=" << conn[8] << ", conn[" << (int)conn.size() - 1 << "]=" << conn.back() << endl;
+    for (int & i : conn)
+        i--; //decrementing for C++ Covise indexes from zero
+    cout << "zone::read(): Connectivities after decrement: conn[0]=" << conn[0] << ", conn[9]=" << conn[8] << ", conn[" << conn.size() - 1 << "]=" << conn.back() << endl;
 
     //7. Reading Solution
 
@@ -123,23 +121,23 @@ int zone::read()
 
     //is solution is  vertex based, load from rmin to rmax (=zonesize[3])
 
-    size_t solmin = 0, solmax = 0;
+    cgsize_t solmin = 0, solmax = 0;
 
     switch (solloc)
     {
     case CGNS_ENUMV(Vertex): //vertex based
-        solmax = fx.size();
+        solmax = static_cast<cgsize_t>(fx.size());
         solmin = 1;
         cout << "zone::read(): Solution is vertex based" << endl;
         break;
     case CGNS_ENUMV(CellCenter): //cell based
         solmin = 1; //universal
-        solmax = tl.size();
+        solmax = static_cast<cgsize_t>(tl.size());
         cout << "zone::read(): Solution is cell based" << endl;
         break;
 
     default:
-        CoviseBase::sendError("zone::read(): Solution location type %d is not supported", (int)solloc);
+        CoviseBase::sendError("zone::read(): Solution location type %d is not supported", static_cast<int>(solloc));
         cout << cout_red << cout_underln << "zone::read(): Solution location type " << (int)solloc << " is not supported" << cout_norm << endl;
         return FAIL;
     }
@@ -151,7 +149,6 @@ int zone::read()
     {
         scalar[i].insert(scalar[i].begin(), solmax - solmin + 1, 0);
         //check!  field load func. needs right size of arrays.
-        int error = 0;
         error = read_field(isol, p.param_f[i], solmin, solmax, scalar[i]);
         if (error)
         {
@@ -209,11 +206,32 @@ int zone::read()
  * index_file,ibase,izone -- obsolete, not used now!
  * vectors -- float vectors with size=zonesize[0] (number of points). Don't use empty vectors!
  */
-int zone::read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz)
+
+
+/**
+ * Read the coordinates array members (fx,fy,fz).
+ *
+ * The arrays will be cleaned before reading into them.
+ *
+ *  A zone has only one set of coord arrays,
+ *  so this function should be called once.
+ *
+ * zonesize member must be set and contain array sizes!
+ *
+ * @return SUCCESS or FAIL
+ */
+int zone::read_coords()
 {
+    // prepare the arrays
+    fx.clear();
+    fy.clear();
+    fz.clear();
+
+    fx.insert(fx.begin(), zonesize[0], 0);
+    fy.insert(fy.begin(), zonesize[0], 0);
+    fz.insert(fz.begin(), zonesize[0], 0);
     //=========GridCoordinates_t=========
-    int error = 0;
-    int numgrids = 0, igrid = 1; //i know that I have 1 "grid"
+    int numgrids = 0, igrid = 1; //I know that I have 1 "grid"
     char gridname[100];
 
     cout << cout_cyan << "zone::read_coords():==========read_coords started================" << cout_norm << endl;
@@ -263,7 +281,7 @@ int zone::read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz)
 
     cgsize_t rmin = 1; //minimal CGNS index of coord array
     //int rmax=zonesize[0]; //maximal CGNS index of coord array
-    cgsize_t rmax = (cgsize_t)fx.size(); // vector size MUST be = zonesize(0)
+    auto rmax = static_cast<cgsize_t>(fx.size()); // vector size MUST be = zonesize(0)
 
     //Datatypes must be the same now for every coord array; function reads 3 first arrays as X,Y,Z
 
@@ -276,8 +294,8 @@ int zone::read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz)
         vector<double> z(fz.size());
 
         error = cg_coord_read(index_file, ibase, izone, coordnames[0].c_str(), CGNS_ENUMV(RealDouble), &rmin, &rmax, &x[0]);
-        error = cg_coord_read(index_file, ibase, izone, coordnames[1].c_str(), CGNS_ENUMV(RealDouble), &rmin, &rmax, &y[0]);
-        error = cg_coord_read(index_file, ibase, izone, coordnames[2].c_str(), CGNS_ENUMV(RealDouble), &rmin, &rmax, &z[0]);
+        cg_coord_read(index_file, ibase, izone, coordnames[1].c_str(), CGNS_ENUMV(RealDouble), &rmin, &rmax, &y[0]);
+        cg_coord_read(index_file, ibase, izone, coordnames[2].c_str(), CGNS_ENUMV(RealDouble), &rmin, &rmax, &z[0]);
 
         copy(x.begin(), x.end(), fx.begin());
         copy(y.begin(), y.end(), fy.begin());
@@ -287,8 +305,8 @@ int zone::read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz)
     case CGNS_ENUMV(RealSingle):
         cout << "zone::read_coords(): Reading Float type coordinates:" << endl;
         error = cg_coord_read(index_file, ibase, izone, coordnames[0].c_str(), CGNS_ENUMV(RealSingle), &rmin, &rmax, &fx[0]);
-        error = cg_coord_read(index_file, ibase, izone, coordnames[1].c_str(), CGNS_ENUMV(RealSingle), &rmin, &rmax, &fy[0]);
-        error = cg_coord_read(index_file, ibase, izone, coordnames[2].c_str(), CGNS_ENUMV(RealSingle), &rmin, &rmax, &fz[0]);
+        cg_coord_read(index_file, ibase, izone, coordnames[1].c_str(), CGNS_ENUMV(RealSingle), &rmin, &rmax, &fy[0]);
+        cg_coord_read(index_file, ibase, izone, coordnames[2].c_str(), CGNS_ENUMV(RealSingle), &rmin, &rmax, &fz[0]);
         break;
     default:
         CoviseBase::sendError("zone::read_coords(): type %d is not supported.", (int)datatypes[0]);
@@ -305,26 +323,20 @@ int zone::read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz)
         return FAIL;
     }
 
-    cout << "read_coords: X [0]=" << fx[0] << "; [" << (int)fx.size() - 1 << "]=" << fx.back() << endl;
-    cout << "read_coords: Y [0]=" << fy[0] << "; [" << (int)fy.size() - 1 << "]=" << fy.back() << endl;
-    cout << "read_coords: Z [0]=" << fz[0] << "; [" << (int)fz.size() - 1 << "]=" << fz.back() << endl;
+    cout << "read_coords: X [0]=" << fx[0] << "; [" << fx.size() - 1 << "]=" << fx.back() << endl;
+    cout << "read_coords: Y [0]=" << fy[0] << "; [" << fy.size() - 1 << "]=" << fy.back() << endl;
+    cout << "read_coords: Z [0]=" << fz[0] << "; [" << fz.size() - 1 << "]=" << fz.back() << endl;
 
     return SUCCESS;
 }
 
-/*------------------------------------------------------------------------------------
- * int zone::read_one_section(int index_file, int ibase, int izone, // obs.!
- * int isection, vector <int> &conn, vector <int> &elem, vector <int> &tl)
- *
- * Reads an USG section and INSERTS it into 3 vectors (which can be not empty)
- *
- * index_file,ibase,izone,isection -- as usual for CGNS functions
- *  conn, elem, tl -- vectors to INSERT an USG section
- *------------------------------------------------------------------------------------*/
-
-int zone::read_one_section(int isection, vector<int> &conn, vector<int> &elem, vector<int> &tl)
+/**
+ * Reads an USG section and INSERTS it into 3 member arrays (conn, elem, tl), which can be not empty
+ * @param isection CGNS section number
+ * @return SUCCESS or FAIL
+ */
+int zone::read_one_section(const int isection)
 {
-
     char elemsectname[100];
     int bdry = 0, parentflg = 0;
     cgsize_t start = 0; /// Start section element idx (usially 1)
@@ -347,7 +359,7 @@ int zone::read_one_section(int isection, vector<int> &conn, vector<int> &elem, v
     vector<cgsize_t> elem_offset_tmp; // temporary element offset array for mixed-size element section
     conntemp.insert(conntemp.begin(), eldatasize, 0);
     if (etype != CGNS_ENUMV(MIXED)) {
-        error = cg_elements_read(index_file, ibase, izone, isection, &conntemp[0], NULL);
+        error = cg_elements_read(index_file, ibase, izone, isection, &conntemp[0], nullptr);
         if (error) {
             cout<< cout_red<<"Zone::read_one_section: cg_elements_read failed! Possibly mixed-size element section, etype = "<<etype<<cout_norm<<endl;
             return FAIL;
@@ -372,28 +384,28 @@ int zone::read_one_section(int isection, vector<int> &conn, vector<int> &elem, v
         for (int i = 0; i < end - start + 1; i++)
             elem.push_back((int)(connfirst + 8 * i)); //all elements (hexaeders) are of size 8
         conn.insert(conn.end(), conntemp.begin(), conntemp.end());
-        cout << "zone::read_one_section(): Section " << isection << " has CG_HEXA_8 type, sizes=tl:" << (int)tl.size() << " elem:" << (int)elem.size() << endl;
+        cout << "zone::read_one_section(): Section " << isection << " has CG_HEXA_8 type, sizes=tl:" << tl.size() << " elem:" << elem.size() << endl;
         break;
     case CGNS_ENUMV(TETRA_4): //=10
         tl.insert(tl.end(), end - start + 1, TYPE_TETRAHEDER);
         for (int i = 0; i < end - start + 1; ++i)
             elem.push_back((int)(connfirst + 4 * i)); // indices begin from connfirst
         conn.insert(conn.end(), conntemp.begin(), conntemp.end());
-        cout << "zone::read_one_section(): Section " << isection << " has CG_TETRA_4 type, sizes=tl:" << (int)tl.size() << " elem:" << (int)elem.size() << endl;
+        cout << "zone::read_one_section(): Section " << isection << " has CG_TETRA_4 type, sizes=tl:" << tl.size() << " elem:" << elem.size() << endl;
         break;
     case CGNS_ENUMV(QUAD_4): //=7
         tl.insert(tl.end(), end - start + 1, TYPE_QUAD);
         for (int i = 0; i < end - start + 1; ++i)
             elem.push_back((int)(connfirst + 4 * i)); // indices begin from connfirst
         conn.insert(conn.end(), conntemp.begin(), conntemp.end());
-        cout << "zone::read_one_section(): Section " << isection << " has CG_QUAD_4 type, sizes=tl:" << (int)tl.size() << " elem:" << (int)elem.size() << endl;
+        cout << "zone::read_one_section(): Section " << isection << " has CG_QUAD_4 type, sizes=tl:" << tl.size() << " elem:" << elem.size() << endl;
         break;
     case CGNS_ENUMV(TRI_3): //=5
         tl.insert(tl.end(), end - start + 1, TYPE_TRIANGLE);
         for (int i = 0; i < end - start + 1; ++i)
-            elem.push_back(connfirst + 3 * i); // indices begin from connfirst
+            elem.push_back((int)connfirst + 3 * i); // indices begin from connfirst
         conn.insert(conn.end(), conntemp.begin(), conntemp.end());
-        cout << "zone::read_one_section(): Section " << isection << " has CG_TRI_3 type, sizes=tl:" << (int)tl.size() << " elem:" << (int)elem.size() << endl;
+        cout << "zone::read_one_section(): Section " << isection << " has CG_TRI_3 type, sizes=tl:" << tl.size() << " elem:" << elem.size() << endl;
         break;
     case CGNS_ENUMV(MIXED): // =20 ; now loads with conn. type member deletion
     {
@@ -409,28 +421,28 @@ int zone::read_one_section(int isection, vector<int> &conn, vector<int> &elem, v
                 tl.push_back(TYPE_HEXAEDER); //pushing one more element_type into type list
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 8);
-                elem.push_back((int)(connfirst + i + 1 - erases)); //pushing 1st element member (cleaned conn) index into element list
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases)); //pushing 1st element member (cleaned conn) index into element list
                 i += 9; // 8+1					// goto next element_type connectivity element
                 break;
             case CGNS_ENUMV(TETRA_4): //CG_TETRA_4 = 10
                 tl.push_back(TYPE_TETRAHEDER);
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 4);
-                elem.push_back((int)(connfirst + i + 1 - erases));
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases));
                 i += 5; //4+1
                 break;
             case CGNS_ENUMV(PYRA_5): //CG_PYRA_5 = 12
                 tl.push_back(TYPE_PYRAMID);
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 5);
-                elem.push_back((int)(connfirst + i + 1 - erases));
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases));
                 i += 6;
                 break;
             case CGNS_ENUMV(PENTA_6): //CG_PENTA_6=14
                 tl.push_back(TYPE_PRISM);
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 6);
-                elem.push_back((int)(connfirst + i + 1 - erases));
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases));
                 i += 7;
                 break;
             //	2D primitives
@@ -438,14 +450,14 @@ int zone::read_one_section(int isection, vector<int> &conn, vector<int> &elem, v
                 tl.push_back(TYPE_TRIANGLE);
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 3);
-                elem.push_back((int)(connfirst + i + 1 - erases));
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases));
                 i += 4;
                 break;
             case CGNS_ENUMV(QUAD_4): //=7
                 tl.push_back(TYPE_QUAD);
                 erases++;
                 conn.insert(conn.end(), &conntemp[i + 1], (&conntemp[i + 1]) + 4);
-                elem.push_back((int)(connfirst + i + 1 - erases));
+                elem.push_back(static_cast<int>(connfirst + i + 1 - erases));
                 i += 5;
                 break;
 
@@ -492,8 +504,8 @@ int zone::select_sections(vector<int> &sections)
     if (p.b_use_string) //using sections string
     {
         cout << "zone::select_sections(): Using section string" << endl;
-        string paramstr; //,tempstr;
-        paramstr = p.sections_string;
+
+        string paramstr = p.sections_string;
 
         cout << "zone::select_sections(): string= " << paramstr << endl;
 
@@ -507,7 +519,7 @@ int zone::select_sections(vector<int> &sections)
             if (tempstr >> isection)
             {
                 sections.push_back(isection);
-                sectnames.push_back(int2str(isection)); //temp!!!
+                sectnames.push_back(std::to_string(isection)); //temp!!!
             }
             else
             {
@@ -518,7 +530,7 @@ int zone::select_sections(vector<int> &sections)
     } //use sections string
     else //loading only 2d or only 3d
     {
-        bool need2d = p.b_load_2d;
+        const bool need2d = p.b_load_2d;
         if (need2d)
             cout << "zone::select_sections(): Loading only 2D meshes" << endl;
         else
@@ -626,7 +638,7 @@ int zone::select_sections(vector<int> &sections)
 
 bool zone::IsMixed3D(const vector<cgsize_t> &conntemp)
 {
-    cgsize_t i = 0;
+    size_t i = 0;
     while (i < conntemp.size())
     {
         switch (conntemp[i]) //cycling through element_type connectivity array elements
@@ -656,31 +668,12 @@ bool zone::IsMixed3D(const vector<cgsize_t> &conntemp)
             break;
 
         default:
-            CoviseBase::sendError("IsMixed3D: Element of mixed unstructured grid is not supported: %ld, i=%ld", (long)conntemp[i], (long)i);
+            CoviseBase::sendError("IsMixed3D: Element of mixed unstructured grid is not supported: %ld, i=%ld", static_cast<long>(conntemp[i]), i);
             return false;
         } //switch conntemp
     } //while conntemp
     return false;
 }
-
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//+++          Solution reading functions              +++
-//+++                                                  +++
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-//++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-//  for_each() function
-/*
-
-struct func_copyd2f // for STL for_each
-{
-	const double *dbl;
-	float *flt;
-	func_copyd2f(const double *_dbl, float *_flt): dbl(_dbl),flt(_flt) {}
-	void operator () (int i) {flt[i]=dbl[i];}
-};
-*/
 
 /*========================================================================
  * Loading the ifield plot field
@@ -698,12 +691,11 @@ struct func_copyd2f // for STL for_each
  * -1 if isol=0 or solution type is not supported
  * cgns error value on reading error
  *=========================================================================*/
-int zone::read_field(int isol, int ifield, cgsize_t start, cgsize_t end, vector<float> &fvar)
+int zone::read_field(const int isol, const int ifield, const cgsize_t start, const cgsize_t end, vector<float> &fvar)
 {
 
     char fieldname[100];
     CGNS_ENUMT(DataType_t) fieldtype;
-    int error = 0;
 
     cout << cout_cyan << "zone::read_field() started. zone=" << izone << " field=" << ifield << cout_norm << endl;
 
@@ -785,7 +777,7 @@ coDistributedObject *zone::create_do(const char *name, int type, int scal_no)
         break;
     default:
         cout << cout_red << "zone::create_do(): ERROR! Invalid object type." << cout_norm << endl;
-        return NULL;
+        return nullptr;
     }
     return d_obj;
 }
@@ -798,10 +790,9 @@ coDistributedObject *zone::create_do(const char *name, int type, int scal_no)
  *----------------------------------------------------------------------*/
 coDoUnstructuredGrid *zone::create_do_grid(const char *usgobjname)
 {
-    coDoUnstructuredGrid *gridobj;
-    gridobj = new coDoUnstructuredGrid(usgobjname, elem.size(), conn.size(), zonesize[0],
-                                       &elem[0], &conn[0], &fx[0], &fy[0], &fz[0], &tl[0]);
-    return gridobj;
+    return new coDoUnstructuredGrid(usgobjname,
+        static_cast<int>(elem.size()),  static_cast<int>(conn.size()), static_cast<int>(zonesize[0]),
+        &elem[0], &conn[0], &fx[0], &fy[0], &fz[0], &tl[0]);
 }
 
 /*-------------------------------------------------------
@@ -812,14 +803,12 @@ coDoUnstructuredGrid *zone::create_do_grid(const char *usgobjname)
  *-------------------------------------------------------*/
 coDoVec3 *zone::create_do_vec(const char *velobjname)
 {
-    if (fvx.size() == 0)
-    {
+    if (fvx.empty()) {
         cout << cout_magenta << "zone::create_do_vec(): WARNING! Empty VECTOR array, returning NULL. "
              << "Zone=" << izone << "; size=" << fvx.size() << cout_norm << endl;
-        return NULL;
+        return nullptr;
     }
-    coDoVec3 *velobj;
-    velobj = new coDoVec3(velobjname, (int)fvx.size(), &fvx[0], &fvy[0], &fvz[0]);
+    auto *velobj = new coDoVec3(velobjname, static_cast<int>(fvx.size()), &fvx[0], &fvy[0], &fvz[0]);
     return velobj;
 }
 /*---------------------------------------------------------
@@ -829,22 +818,22 @@ coDoVec3 *zone::create_do_vec(const char *velobjname)
  * const char * usgobjname -- object name
  * n -- number of scalar field (0-3)
  */
-coDoFloat *zone::create_do_scalar(const char *floatobjname, int n)
+coDoFloat *zone::create_do_scalar(const char *floatobjname, const int n)
 {
     if ((n < 0) || (n > 3))
     {
         cout << "zone::create_do_scalar(): ERROR! scalar index is out of range!" << endl;
-        return NULL;
+        return nullptr;
     }
-    if (scalar[n].size() == 0)
+    if (scalar[n].empty())
     {
         cout << cout_magenta << "zone::create_do_scalar(): WARNING! Empty SCALAR array, returning NULL;"
              << "Zone=" << izone << " no=" << n + 1 << "; size=" << scalar[n].size() << cout_norm << endl;
 
-        return NULL;
+        return nullptr;
     }
-    coDoFloat *floatobj = NULL;
-    floatobj = new coDoFloat(floatobjname, (int)scalar[n].size(), &scalar[n][0]);
+    coDoFloat *floatobj = nullptr;
+    floatobj = new coDoFloat(floatobjname, static_cast<int>(scalar[n].size()), &scalar[n][0]);
 
     //cout<<"zone::create_do_scalar(): zone="<<izone<<" no="<<n+1<<"; size="<<scalar[n].size()<<"; floatobj="<<floatobj<<endl;
     return floatobj;

--- a/src/module/spbgpu/ReadCGNS/zone.h
+++ b/src/module/spbgpu/ReadCGNS/zone.h
@@ -18,7 +18,7 @@
 #define ZONE_H_
 
 #include <vector>
-#include <string>
+//#include <string>
 #include <cgnslib.h>
 #include <do/coDoUnstructuredGrid.h> //for grid element types
 #include <do/coDoData.h>
@@ -29,9 +29,9 @@ using namespace covise;
 
 class zone
 {
-    //from COMODULE
-
+    /// Error return for CGNS lib
     int error;
+    //from COMODULE
     enum
     {
         FAIL = -1,

--- a/src/module/spbgpu/ReadCGNS/zone.h
+++ b/src/module/spbgpu/ReadCGNS/zone.h
@@ -29,8 +29,8 @@ using namespace covise;
 
 class zone
 {
-    /// Error return for CGNS lib
-    int error;
+    int error{0}; /// Error return for CGNS lib
+
     //from COMODULE
     enum
     {
@@ -38,50 +38,49 @@ class zone
         SUCCESS = 0 //return values
     };
 
-    //vars
-    int index_file;
-    int ibase;
-    int izone;
+    //CGNS indices for zone
+
+    int index_file;  /// CGNS file index
+    int ibase;      /// CGNS base index
+    int izone;      /// CGNS zone index
     params p;
 
-    //coords array
-    vector<float> fx;
-    vector<float> fy;
-    vector<float> fz;
+    vector<float> fx; /// COVISE X coord array
+    vector<float> fy; /// COVISE Y coord array
+    vector<float> fz; /// COVISE Z coord array
 
-    vector<int> conn; //connectivity array
-    vector<int> tl; //type list arraay
-    vector<int> elem; //element list array
+    vector<int> conn; /// COVISE connectivity array
+    vector<int> tl;   /// COVISE type list arraay
+    vector<int> elem; /// COVISE element list array
 
-    //4 float fields
-    vector<float> scalar[4];
+    vector<float> scalar[4]; /// COVISE scalar fields
 
     //velocity vector
-    vector<float> fvx;
-    vector<float> fvy;
-    vector<float> fvz;
 
-    cgsize_t zonesize[3]; //3 sizes for unstructured grid
+    vector<float> fvx;  /// COVISE velocity x
+    vector<float> fvy;  /// COVISE velocity y
+    vector<float> fvz;  /// COVISE velocity z
 
-    char zonename[100];
+    cgsize_t zonesize[9]; /// CGNS 3 sizes for unstructured grid; max 9 for 3d structured
 
-    CGNS_ENUMT(ZoneType_t) zonetype;
+    char zonename[100];  /// CGNS zone name
+
+    CGNS_ENUMT(ZoneType_t) zonetype; /// CGNS zone type
 
     //solution-related
     int read_field(int isol, int ifield, cgsize_t start, cgsize_t end, vector<float> &fvar);
 
     //coord related
-    int read_coords(vector<float> &fx, vector<float> &fy, vector<float> &fz);
+    int read_coords();
 
     //section related
-    int read_one_section(int isection, vector<int> &conn, vector<int> &elem, vector<int> &tl);
+    int read_one_section(int isection);
     int select_sections(vector<int> &sections);
-    bool IsMixed3D(const vector<cgsize_t> &conntemp);
+    static bool IsMixed3D(const vector<cgsize_t> &conntemp);
 
 public:
     //zone ();
     zone(int i_file, int i_base, int i_zone, params _p);
-    //int read (int index_file,int ibase,int izone);
     int read();
 
     coDoUnstructuredGrid *create_do_grid(const char *usgobjname);


### PR DESCRIPTION
-- Fix for libcgns 3.4+: CPEX 41 NGON modification proposal.

CGNS library v.3.4+ API and file format change:
For MIXED and NGON section types:
1. Old cg_elements_read() fails,
2. Introduced new ElementStartOffset array,
3. Introduced new cg_poly_elements_read() function that reads
    ElementConnectivity and ElementStartOffset arrays,
4. In new CGNS file format, ElementConnectivity stays the same,
   they just added ElementStartOffset array.

-- Also fixed crash when trying to read structural grids.
